### PR TITLE
consistent whitespace & PEP8 compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PYLINT_FILES= nbt/ examples/ tests/
+
+check:
+	pep8 -r --ignore=E501,W191,E101 $(PYLINT_FILES)
+	pyflakes $(PYLINT_FILES)
+	pylint --output-format=parseable -rn -iy --disable=W0312 --max-line-length=120 --good-names=x,y,z $(PYLINT_FILES)
+
+test:
+	python tests/alltests.py
+    

--- a/examples/biome_analysis.py
+++ b/examples/biome_analysis.py
@@ -2,33 +2,32 @@
 """
 Counter the number of biomes in the world. Works only for Anvil-based world folders.
 """
-import locale, os, sys
-from struct import pack, unpack
+import locale
+import os
+import sys
 
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
-from nbt.region import RegionFile
-from nbt.chunk import Chunk
-from nbt.world import AnvilWorldFolder,UnknownWorldFormat
+from nbt.world import AnvilWorldFolder
 
 BIOMES = {
-	0 : "Ocean",
-	1 : "Plains",
-	2 : "Desert",
-	3 : "Mountains",
-	4 : "Forest",
-	5 : "Taiga",
-	6 : "Swamp",
-	7 : "River",
-	8 : "Nether",
-	9 : "Sky",
+	0: "Ocean",
+	1: "Plains",
+	2: "Desert",
+	3: "Mountains",
+	4: "Forest",
+	5: "Taiga",
+	6: "Swamp",
+	7: "River",
+	8: "Nether",
+	9: "Sky",
 	10: "Frozen Ocean",
 	11: "Frozen River",
 	12: "Ice Plains",
@@ -48,15 +47,15 @@ BIOMES = {
 
 def print_results(biome_totals):
 	locale.setlocale(locale.LC_ALL, '')
-	for id,count in enumerate(biome_totals):
+	for id, count in enumerate(biome_totals):
 		# Biome ID 255 is ignored. It means it is not calculated by Minecraft yet
 		if id == 255 or (count == 0 and id not in BIOMES):
 			continue
 		if id in BIOMES:
-			biome = BIOMES[id]+" (%d)" % id
+			biome = BIOMES[id] + " (%d)" % id
 		else:
 			biome = "Unknown (%d)" % id
-		print(locale.format_string("%-25s %10d", (biome,count)))
+		print(locale.format_string("%-25s %10d", (biome, count)))
 
 
 def main(world_folder):
@@ -64,8 +63,8 @@ def main(world_folder):
 	if not world.nonempty():  # likely still a McRegion file
 		sys.stderr.write("World folder %r is empty or not an Anvil formatted world\n" % world_folder)
 		return 65  # EX_DATAERR
-	biome_totals = [0]*256 # 256 counters for 256 biome IDs
-	
+	biome_totals = [0] * 256  # 256 counters for 256 biome IDs
+
 	try:
 		for chunk in world.iter_nbt():
 			for biomeid in chunk["Level"]["Biomes"]:
@@ -73,19 +72,19 @@ def main(world_folder):
 
 	except KeyboardInterrupt:
 		print_results(biome_totals)
-		return 75 # EX_TEMPFAIL
-	
+		return 75  # EX_TEMPFAIL
+
 	print_results(biome_totals)
-	return 0 # NOERR
+	return 0  # NOERR
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified!")
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+
 	sys.exit(main(world_folder))

--- a/examples/block_analysis.py
+++ b/examples/block_analysis.py
@@ -3,82 +3,87 @@
 Finds the contents of the different blocks in a level, taking different data values (sub block types) into account.
 """
 
-import locale, os, sys
 import glob
+import locale
+import os
+import sys
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 from nbt.region import RegionFile
 from nbt.chunk import Chunk
+
 
 def stats_per_chunk(chunk, block_data_totals):
 	"""Given a chunk, increment the block types with the number of blocks found"""
 	for block_id, data_id in chunk.blocks.get_all_blocks_and_data():
 		block_data_totals[block_id][data_id] += 1
 
+
 def bounded_stats_per_chunk(chunk, block_data_totals, start, stop):
 	"""Given a chunk, return the number of blocks types within the specified selection"""
 	chunk_z, chunk_x = chunk.get_coords()
 	for z in range(16):
-		world_z = z + chunk_z*16
-		if ( (start != None and world_z < int(start[2])) or (stop != None and  world_z > int(stop[2])) ):
+		world_z = z + chunk_z * 16
+		if ((start != None and world_z < int(start[2])) or (stop != None and  world_z > int(stop[2]))):
 			# Outside the bounding box; skip to next iteration
 			#print("Z break: %d,%d,%d" % (world_z,start[2],stop[2]))
 			break
 		for x in range(16):
-			world_x = x + chunk_x*16
-			if ( (start != None and world_x < int(start[0])) or (stop != None and world_x > int(stop[0])) ):
+			world_x = x + chunk_x * 16
+			if((start != None and world_x < int(start[0])) or (stop != None and world_x > int(stop[0]))):
 				# Outside the bounding box; skip to next iteration
 				#print("X break: %d,%d,%d" % (world_x,start[0],stop[0]))
 				break
 			for y in range(128):
-				if ( (start != None and y < int(start[1])) or (stop != None and y > int(stop[1])) ):
+				if ((start != None and y < int(start[1])) or (stop != None and y > int(stop[1]))):
 					# Outside the bounding box; skip to next iteration
 					#print("Y break: %d,%d,%d" % (y,start[1],stop[1]))
 					break
-				
+
 				#print("Chunk: %d,%d Coord: %d,%d,%d" % (c['x'], c['z'],x,y,z))
-				block_id,block_data = chunk.blocks.get_block_and_data(x,y,z)
+				block_id, block_data = chunk.blocks.get_block_and_data(x, y, z)
 				block_data_totals[block_id][block_data] += 1
+
 
 def process_region_file(filename, start, stop):
 	"""Given a region filename, return the number of blocks of each ID in that file"""
 	pieces = filename.split('.')
 	rx = int(pieces[1])
 	rz = int(pieces[2])
-	
-	block_data_totals = [[0]*16 for i in range(256)] # up to 16 data numbers in 256 block IDs
-	
+
+	block_data_totals = [[0] * 16 for i in range(256)]  # up to 16 data numbers in 256 block IDs
+
 	# Does the region overlap the bounding box at all?
 	if (start != None):
-		if ( (rx+1)*512-1 < int(start[0]) or (rz+1)*512-1 < int(start[2]) ):
+		if ((rx + 1) * 512 - 1 < int(start[0]) or (rz + 1) * 512 - 1 < int(start[2])):
 			return block_data_totals
 	elif (stop != None):
-		if ( rx*512-1 > int(stop[0]) or rz*512-1 > int(stop[2]) ):
+		if (rx * 512 - 1 > int(stop[0]) or rz * 512 - 1 > int(stop[2])):
 			return block_data_totals
-	
+
 	file = RegionFile(filename)
-	
+
 	# Get all chunks
 	chunks = file.get_chunks()
-	print("Parsing %s... %d chunks" % (os.path.basename(filename),len(chunks)))
+	print("Parsing %s... %d chunks" % (os.path.basename(filename), len(chunks)))
 	for c in chunks:
 		# Does the chunk overlap the bounding box at all?
 		if (start != None):
-			if ( (c['x']+1)*16 + rx*512 - 1 < int(start[0]) or (c['z']+1)*16 + rz*512 - 1 < int(start[2]) ):
+			if ((c['x'] + 1) * 16 + rx * 512 - 1 < int(start[0]) or (c['z'] + 1) * 16 + rz * 512 - 1 < int(start[2])):
 				continue
 		elif (stop != None):
-			if ( c['x']*16 + rx*512 - 1 > int(stop[0]) or c['z']*16 + rz*512 - 1 > int(stop[2]) ):
+			if (c['x'] * 16 + rx * 512 - 1 > int(stop[0]) or c['z'] * 16 + rz * 512 - 1 > int(stop[2])):
 				continue
-		
+
 		chunk = Chunk(file.get_chunk(c['x'], c['z']))
-		assert chunk.get_coords() == (c['x'] + rx*32, c['z'] + rz*32)
+		assert chunk.get_coords() == (c['x'] + rx * 32, c['z'] + rz * 32)
 		#print("Parsing chunk ("+str(c['x'])+", "+str(c['z'])+")")
 		# Parse the blocks
 
@@ -89,25 +94,25 @@ def process_region_file(filename, start, stop):
 		else:
 			# Slow code that iterates through each coordinate
 			bounded_stats_per_chunk(chunk, block_data_totals, start, stop)
-	
+
 	return block_data_totals
 
 
 def print_results(block_data_totals):
 	locale.setlocale(locale.LC_ALL, '')
-	
+
 	# Analyze blocks
-	for block_id,data in enumerate(block_data_totals):
+	for block_id, data in enumerate(block_data_totals):
 		if sum(data) > 0:
-			datastr = ", ".join([locale.format_string("%d: %d", (i,c), grouping=True) for (i,c) in enumerate(data) if c > 0])
-			print(locale.format_string("block id %3d: %12d (data id %s)", (block_id,sum(data),datastr), grouping=True))
+			datastr = ", ".join([locale.format_string("%d: %d", (i, c), grouping=True) for (i, c) in enumerate(data) if c > 0])
+			print(locale.format_string("block id %3d: %12d (data id %s)", (block_id, sum(data), datastr), grouping=True))
 	block_totals = [sum(data_totals) for data_totals in block_data_totals]
-	
+
 	total_blocks = sum(block_totals)
 	solid_blocks = total_blocks - block_totals[0]
-	solid_ratio = (solid_blocks+0.0)/total_blocks if (total_blocks > 0) else 0
-	print(locale.format_string("%d total blocks in region, %d are non-air (%0.4f", (total_blocks, solid_blocks, 100.0*solid_ratio), grouping=True)+"%)")
-	
+	solid_ratio = (solid_blocks + 0.0) / total_blocks if (total_blocks > 0) else 0
+	print(locale.format_string("%d total blocks in region, %d are non-air (%0.4f", (total_blocks, solid_blocks, 100.0 * solid_ratio), grouping=True) + "%)")
+
 	# Find valuable blocks
 	print(locale.format_string("Diamond Ore:      %8d", block_totals[56], grouping=True))
 	print(locale.format_string("Gold Ore:         %8d", block_totals[14], grouping=True))
@@ -116,7 +121,7 @@ def print_results(block_data_totals):
 	print(locale.format_string("Coal Ore:         %8d", block_totals[16], grouping=True))
 	print(locale.format_string("Lapis Lazuli Ore: %8d", block_totals[21], grouping=True))
 	print(locale.format_string("Dungeons:         %8d", block_totals[52], grouping=True))
-	
+
 	print(locale.format_string("Clay:             %8d", block_totals[82], grouping=True))
 	print(locale.format_string("Sugar Cane:       %8d", block_totals[83], grouping=True))
 	print(locale.format_string("Cacti:            %8d", block_totals[81], grouping=True))
@@ -126,46 +131,45 @@ def print_results(block_data_totals):
 	print(locale.format_string("Brown Mushroom:   %8d", block_totals[39], grouping=True))
 	print(locale.format_string("Red Mushroom:     %8d", block_totals[40], grouping=True))
 	print(locale.format_string("Lava Springs:     %8d", block_totals[11], grouping=True))
-	
 
 
 def main(world_folder, start=None, stop=None):
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		return 2 # ENOENT
-	
-	regions = glob.glob(os.path.join(world_folder,'region','*.mcr'))
-	
-	block_data_totals = [[0]*16 for i in range(256)] # up to 16 data numbers in 256 block IDs
+		print("No such folder as " + world_folder)
+		return 2  # ENOENT
+
+	regions = glob.glob(os.path.join(world_folder, 'region', '*.mcr'))
+
+	block_data_totals = [[0] * 16 for i in range(256)]  # up to 16 data numbers in 256 block IDs
 	try:
 		for filename in regions:
 			region_totals = process_region_file(filename, start, stop)
 			for i, data in enumerate(region_totals):
 				for j, total in enumerate(data):
 					block_data_totals[i][j] += total
-	
+
 	except KeyboardInterrupt:
 		print_results(block_data_totals)
-		return 75 # EX_TEMPFAIL
-	
+		return 75  # EX_TEMPFAIL
+
 	print_results(block_data_totals)
-	return 0 # EX_OK
+	return 0  # EX_OK
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified! Usage: %s <world folder> [minx,miny,minz maxx,maxy,maxz]" % sys.argv[0])
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	start,stop = None,None
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+	start, stop = None, None
 	if (len(sys.argv) == 4):
 		# A min/max corner was specified
-		start_str = sys.argv[2][1:-1] # Strip parenthesis...
-		start = tuple(start_str.split(',')) # and convert to tuple
-		stop_str = sys.argv[3][1:-1] # Strip parenthesis...
-		stop = tuple(stop_str.split(',')) # and convert to tuple
-	
+		start_str = sys.argv[2][1:-1]  # Strip parenthesis...
+		start = tuple(start_str.split(','))  # and convert to tuple
+		stop_str = sys.argv[3][1:-1]  # Strip parenthesis...
+		stop = tuple(stop_str.split(','))  # and convert to tuple
+
 	sys.exit(main(world_folder, start, stop))

--- a/examples/chest_analysis.py
+++ b/examples/chest_analysis.py
@@ -2,33 +2,38 @@
 """
 Finds and prints the contents of chests (including minecart chests)
 """
-import locale, os, sys
+import locale
+import os
+import sys
 
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 from nbt.world import WorldFolder
 
+
 class Position(object):
-	def __init__(self, x,y,z):
+	def __init__(self, x, y, z):
 		self.x = x
 		self.y = y
 		self.z = z
 
+
 class Chest(object):
 	def __init__(self, type, pos, items):
-		self.type  = type
-		self.pos   = Position(*pos)
+		self.type = type
+		self.pos = Position(*pos)
 		self.items = items
 
+
 def items_from_nbt(nbtlist):
-	items = {}	# block_id -> count
+	items = {}  # block_id -> count
 	for item in nbtlist:
 		id = item['id'].value
 		count = item['Count'].value
@@ -37,6 +42,7 @@ def items_from_nbt(nbtlist):
 		items[id] += count
 	return items
 
+
 def chests_per_chunk(chunk):
 	"""Given a chunk, increment the block types with the number of blocks found"""
 	# if (len(chunk['Entities']) > 0) or (len(chunk['TileEntities']) > 0):
@@ -44,17 +50,16 @@ def chests_per_chunk(chunk):
 	entities = []
 	for entity in chunk['Entities']:
 		if entity["id"].value == "Minecart" and entity["type"].value == 1:
-			x,y,z = entity["Pos"]
-			x,y,z = x.value,y,value,z.value
+			x, y, z = entity["Pos"]
+			x, y, z = x.value, y.value, z.value
 			items = items_from_nbt(entity["Items"])
-			entities.append(Chest("Minecart with chest",(x,y,z),items))
+			entities.append(Chest("Minecart with chest", (x, y, z), items))
 	for entity in chunk['TileEntities']:
 		if entity["id"].value == "Chest":
-			x,y,z = entity["x"].value,entity["y"].value,entity["z"].value
+			x, y, z = entity["x"].value, entity["y"].value, entity["z"].value
 			items = items_from_nbt(entity["Items"])
-			entities.append(Chest("Chest",(x,y,z),items))
+			entities.append(Chest("Chest", (x, y, z), items))
 	return entities
-
 
 
 def print_results(chests):
@@ -63,34 +68,34 @@ def print_results(chests):
 		itemcount = sum(chest.items.values())
 		print("%s at %s,%s,%s with %d items:" % \
 			(chest.type,\
-			locale.format("%0.1f",chest.pos.x,grouping=True),\
-			locale.format("%0.1f",chest.pos.y,grouping=True),\
-			locale.format("%0.1f",chest.pos.z,grouping=True),\
+			locale.format("%0.1f", chest.pos.x, grouping=True),\
+			locale.format("%0.1f", chest.pos.y, grouping=True),\
+			locale.format("%0.1f", chest.pos.z, grouping=True),\
 			itemcount))
-		for blockid,count in chest.items.items():
+		for blockid, count in chest.items.items():
 			print("   %3dx Item %d" % (count, blockid))
 
 
 def main(world_folder):
 	world = WorldFolder(world_folder)
-	
+
 	try:
 		for chunk in world.iter_nbt():
 			print_results(chests_per_chunk(chunk["Level"]))
 
 	except KeyboardInterrupt:
-		return 75 # EX_TEMPFAIL
-	
-	return 0 # NOERR
+		return 75  # EX_TEMPFAIL
+
+	return 0  # NOERR
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified!")
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+
 	sys.exit(main(world_folder))

--- a/examples/generate_level_dat.py
+++ b/examples/generate_level_dat.py
@@ -4,9 +4,10 @@ Create a file that can be used as a basic level.dat file with all required field
 """
 # http://www.minecraftwiki.net/wiki/Alpha_Level_Format#level.dat_Format
 
-import os,sys
-import time
+import os
 import random
+import sys
+import time
 
 # local module
 try:
@@ -14,14 +15,14 @@ try:
 	from nbt.nbt import *
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 	from nbt.nbt import *
 
 
-level = NBTFile() # Blank NBT
+level = NBTFile()  # Blank NBT
 level.name = "Data"
 level.tags.extend([
 	TAG_Long(name="Time", value=1),
@@ -30,7 +31,7 @@ level.tags.extend([
 	TAG_Int(name="SpawnY", value=2),
 	TAG_Int(name="SpawnZ", value=0),
 	TAG_Long(name="SizeOnDisk", value=0),
-	TAG_Long(name="RandomSeed", value=random.randrange(1,9999999999)),
+	TAG_Long(name="RandomSeed", value=random.randrange(1, 9999999999)),
 	TAG_Int(name="version", value=19132),
 	TAG_String(name="LevelName", value="Testing")
 ])

--- a/examples/map.py
+++ b/examples/map.py
@@ -3,113 +3,120 @@
 Prints a map of the entire world.
 """
 
-import locale, os, sys
-import re, math
-from struct import pack, unpack
+import locale
+import math
+import os
+
+import sys
+from struct import pack
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
-from nbt.region import RegionFile
-from nbt.chunk import Chunk
-from nbt.world import WorldFolder,McRegionWorldFolder
+from nbt.world import McRegionWorldFolder
 # PIL module (not build-in)
 try:
 	from PIL import Image
 except ImportError:
 	# PIL not in search path. Let's see if it can be found in the parent folder
 	sys.stderr.write("Module PIL/Image not found. PIL can be found at http://www.pythonware.com/library/pil/")
-	sys.exit(70) # EX_SOFTWARE
+	sys.exit(70)  # EX_SOFTWARE
+
 
 def get_heightmap_image(chunk, buffer=False, gmin=False, gmax=False):
 	points = chunk.blocks.generate_heightmap(buffer, True)
 	# Normalize the points
-	hmin = min(points) if (gmin == False) else gmin # Allow setting the min/max explicitly, in case this is part of a bigger map
+	hmin = min(points) if (gmin == False) else gmin  # Allow setting the min/max explicitly, in case this is part of a bigger map
 	hmax = max(points) if (gmax == False) else gmax
-	hdelta = hmax-hmin+0.0
+	hdelta = hmax - hmin + 0.0
 	pixels = ""
 	for y in range(16):
 		for x in range(16):
 			# pix X => mc -Z
 			# pix Y => mc X
-			offset = (15-x)*16+y
-			height = int((points[offset]-hmin)/hdelta*255)
-			if (height < 0): height = 0
-			if (height > 255): height = 255
+			offset = (15 - x) * 16 + y
+			height = int((points[offset] - hmin) / hdelta * 255)
+			if (height < 0):
+				height = 0
+			if (height > 255):
+				height = 255
 			pixels += pack(">B", height)
-	im = Image.fromstring('L', (16,16), pixels)
+	im = Image.fromstring('L', (16, 16), pixels)
 	return im
+
 
 def get_map(chunk):
 	# Show an image of the chunk from above
 	pixels = ""
 	block_colors = {
-		0: {'h':0, 's':0, 'l':0},       # Air
-		1: {'h':0, 's':0, 'l':32},      # Stone
-		2: {'h':94, 's':42, 'l':32},    # Grass
-		3: {'h':27, 's':51, 'l':15},    # Dirt
-		4: {'h':0, 's':0, 'l':25},      # Cobblestone
-		8: {'h':228, 's':50, 'l':23},   # Water
-		9: {'h':228, 's':50, 'l':23},   # Water
-		10: {'h':16, 's':100, 'l':48},  # Lava
-		11: {'h':16, 's':100, 'l':48},  # Lava
-		12: {'h':53, 's':22, 'l':58},   # Sand
-		13: {'h':21, 's':18, 'l':20},   # Gravel
-		17: {'h':35, 's':93, 'l':15},   # Wood
-		18: {'h':114, 's':64, 'l':22},  # Leaves
-		24: {'h':48, 's':31, 'l':40},   # Sandstone
-		37: {'h':60, 's':100, 'l':60},  # Yellow Flower
-		38: {'h':0, 's':100, 'l':50},   # Red Flower
-		50: {'h':60, 's':100, 'l':50},  # Torch
-		51: {'h':55, 's':100, 'l':50},  # Fire
-		59: {'h':123, 's':60, 'l':50},  # Crops
-		60: {'h':35, 's':93, 'l':15},   # Farmland
-		78: {'h':240, 's':10, 'l':85},  # Snow
-		79: {'h':240, 's':10, 'l':95},  # Ice
-		81: {'h':126, 's':61, 'l':20},  # Cacti
-		82: {'h':7, 's':62, 'l':23},    # Clay
-		83: {'h':123, 's':70, 'l':50},  # Sugarcane
-		86: {'h':24, 's':100, 'l':45},  # Pumpkin
-		91: {'h':24, 's':100, 'l':45},  # Jack-o-lantern
+		0: {'h': 0, 's': 0, 'l': 0},       # Air
+		1: {'h': 0, 's': 0, 'l': 32},      # Stone
+		2: {'h': 94, 's': 42, 'l': 32},    # Grass
+		3: {'h': 27, 's': 51, 'l': 15},    # Dirt
+		4: {'h': 0, 's': 0, 'l': 25},      # Cobblestone
+		8: {'h': 228, 's': 50, 'l': 23},   # Water
+		9: {'h': 228, 's': 50, 'l': 23},   # Water
+		10: {'h': 16, 's': 100, 'l': 48},  # Lava
+		11: {'h': 16, 's': 100, 'l': 48},  # Lava
+		12: {'h': 53, 's': 22, 'l': 58},   # Sand
+		13: {'h': 21, 's': 18, 'l': 20},   # Gravel
+		17: {'h': 35, 's': 93, 'l': 15},   # Wood
+		18: {'h': 114, 's': 64, 'l': 22},  # Leaves
+		24: {'h': 48, 's': 31, 'l': 40},   # Sandstone
+		37: {'h': 60, 's': 100, 'l': 60},  # Yellow Flower
+		38: {'h': 0, 's': 100, 'l': 50},   # Red Flower
+		50: {'h': 60, 's': 100, 'l': 50},  # Torch
+		51: {'h': 55, 's': 100, 'l': 50},  # Fire
+		59: {'h': 123, 's': 60, 'l': 50},  # Crops
+		60: {'h': 35, 's': 93, 'l': 15},   # Farmland
+		78: {'h': 240, 's': 10, 'l': 85},  # Snow
+		79: {'h': 240, 's': 10, 'l': 95},  # Ice
+		81: {'h': 126, 's': 61, 'l': 20},  # Cacti
+		82: {'h': 7, 's': 62, 'l': 23},    # Clay
+		83: {'h': 123, 's': 70, 'l': 50},  # Sugarcane
+		86: {'h': 24, 's': 100, 'l': 45},  # Pumpkin
+		91: {'h': 24, 's': 100, 'l': 45},  # Jack-o-lantern
 	}
 	for z in range(16):
 		for x in range(16):
 			# Find the highest block in this column
 			ground_height = 127
 			tints = []
-			for y in range(127,-1,-1):
-				block_id = chunk.blocks.get_block(x,y,z)
-				block_data = chunk.blocks.get_data(x,y,z)
+			for y in range(127, -1, -1):
+				block_id = chunk.blocks.get_block(x, y, z)
+				block_data = chunk.blocks.get_data(x, y, z)
 				if (block_id == 8 or block_id == 9):
-					tints.append({'h':228, 's':50, 'l':23}) # Water
+					tints.append({'h': 228, 's': 50, 'l': 23})  # Water
 				elif (block_id == 18):
 					if (block_data == 1):
-						tints.append({'h':114, 's':64, 'l':22}) # Redwood Leaves
+						tints.append({'h': 114, 's': 64, 'l': 22})  # Redwood Leaves
 					elif (block_data == 2):
-						tints.append({'h':93, 's':39, 'l':10}) # Birch Leaves
+						tints.append({'h': 93, 's': 39, 'l': 10})  # Birch Leaves
 					else:
-						tints.append({'h':114, 's':64, 'l':22}) # Normal Leaves
+						tints.append({'h': 114, 's': 64, 'l': 22})  # Normal Leaves
 				elif (block_id == 79):
-					tints.append({'h':240, 's':5, 'l':95}) # Ice
+					tints.append({'h': 240, 's': 5, 'l': 95})  # Ice
 				elif (block_id == 51):
-					tints.append({'h':55, 's':100, 'l':50}) # Fire
+					tints.append({'h': 55, 's': 100, 'l': 50})  # Fire
 				elif (block_id != 0 or y == 0):
 					# Here is ground level
 					ground_height = y
 					break
 
-			color = block_colors[block_id] if (block_id in block_colors) else {'h':0, 's':0, 'l':100}
-			height_shift = (ground_height-64)*0.25
-			
-			final_color = {'h':color['h'], 's':color['s'], 'l':color['l']+height_shift}
-			if final_color['l'] > 100: final_color['l'] = 100
-			if final_color['l'] < 0: final_color['l'] = 0
-			
+			color = block_colors[block_id] if (block_id in block_colors) else {'h': 0, 's': 0, 'l': 100}
+			height_shift = (ground_height - 64) * 0.25
+
+			final_color = {'h': color['h'], 's': color['s'], 'l': color['l'] + height_shift}
+			if final_color['l'] > 100:
+				final_color['l'] = 100
+			if final_color['l'] < 0:
+				final_color['l'] = 0
+
 			# Apply tints from translucent blocks
 			for tint in reversed(tints):
 				final_color = hsl_slide(final_color, tint, 0.4)
@@ -117,7 +124,7 @@ def get_map(chunk):
 			rgb = hsl2rgb(final_color['h'], final_color['s'], final_color['l'])
 
 			pixels += pack("BBB", rgb[0], rgb[1], rgb[2])
-	im = Image.fromstring('RGB', (16,16), pixels)
+	im = Image.fromstring('RGB', (16, 16), pixels)
 	return im
 
 
@@ -131,87 +138,92 @@ def hsl_slide(hsl1, hsl2, ratio):
 			hsl1['h'] -= 360
 		else:
 			hsl1['h'] += 360
-	
+
 	# Find location of two colors on the H/S color circle
-	p1x = math.cos(math.radians(hsl1['h']))*hsl1['s']
-	p1y = math.sin(math.radians(hsl1['h']))*hsl1['s']
-	p2x = math.cos(math.radians(hsl2['h']))*hsl2['s']
-	p2y = math.sin(math.radians(hsl2['h']))*hsl2['s']
-	
+	p1x = math.cos(math.radians(hsl1['h'])) * hsl1['s']
+	p1y = math.sin(math.radians(hsl1['h'])) * hsl1['s']
+	p2x = math.cos(math.radians(hsl2['h'])) * hsl2['s']
+	p2y = math.sin(math.radians(hsl2['h'])) * hsl2['s']
+
 	# Slide part of the way from tint to base color
-	avg_x = p1x + ratio*(p2x-p1x)
-	avg_y = p1y + ratio*(p2y-p1y)
-	avg_h = math.atan(avg_y/avg_x)
-	avg_s = avg_y/math.sin(avg_h)
-	avg_l = hsl1['l'] + ratio*(hsl2['l']-hsl1['l'])
+	avg_x = p1x + ratio * (p2x - p1x)
+	avg_y = p1y + ratio * (p2y - p1y)
+	avg_h = math.atan(avg_y / avg_x)
+	avg_s = avg_y / math.sin(avg_h)
+	avg_l = hsl1['l'] + ratio * (hsl2['l'] - hsl1['l'])
 	avg_h = math.degrees(avg_h)
-	
+
 	#print('tint: %s base: %s avg: %s %s %s' % (tint,final_color,avg_h,avg_s,avg_l))
-	return {'h':avg_h, 's':avg_s, 'l':avg_l}
+	return {'h': avg_h, 's': avg_s, 'l': avg_l}
 
 
 # From http://www.easyrgb.com/index.php?X=MATH&H=19#text19
-def hsl2rgb(H,S,L):
-	H = H/360.0
-	S = S/100.0 # Turn into a percentage
-	L = L/100.0
+def hsl2rgb(H, S, L):
+	H = H / 360.0
+	S = S / 100.0  # Turn into a percentage
+	L = L / 100.0
 	if (S == 0):
-		return (int(L*255), int(L*255), int(L*255))
-	var_2 = L * (1+S) if (L < 0.5) else (L+S) - (S*L)
-	var_1 = 2*L - var_2
+		return (int(L * 255), int(L * 255), int(L * 255))
+	var_2 = L * (1 + S) if (L < 0.5) else (L + S) - (S * L)
+	var_1 = 2 * L - var_2
 
 	def hue2rgb(v1, v2, vH):
-		if (vH < 0): vH += 1
-		if (vH > 1): vH -= 1
-		if ((6*vH)<1): return v1 + (v2-v1)*6*vH
-		if ((2*vH)<1): return v2
-		if ((3*vH)<2): return v1 + (v2-v1)*(2/3.0-vH)*6
+		if (vH < 0):
+			vH += 1
+		if (vH > 1):
+			vH -= 1
+		if ((6 * vH) < 1):
+			return v1 + (v2 - v1) * 6 * vH
+		if ((2 * vH) < 1):
+			return v2
+		if ((3 * vH) < 2):
+			return v1 + (v2 - v1) * (2 / 3.0 - vH) * 6
 		return v1
-		
-	R = int(255*hue2rgb(var_1, var_2, H + (1.0/3)))
-	G = int(255*hue2rgb(var_1, var_2, H))
-	B = int(255*hue2rgb(var_1, var_2, H - (1.0/3)))
-	return (R,G,B)
+
+	R = int(255 * hue2rgb(var_1, var_2, H + (1.0 / 3)))
+	G = int(255 * hue2rgb(var_1, var_2, H))
+	B = int(255 * hue2rgb(var_1, var_2, H - (1.0 / 3)))
+	return (R, G, B)
 
 
 def main(world_folder, show=True):
 	world = McRegionWorldFolder(world_folder)  # map still only supports McRegion maps
 	bb = world.get_boundingbox()
-	map = Image.new('RGB', (16*bb.lenx(),16*bb.lenz()))
+	map = Image.new('RGB', (16 * bb.lenx(), 16 * bb.lenz()))
 	t = world.chunk_count()
 	try:
-		i =0.0
+		i = 0.0
 		for chunk in world.iter_chunks():
-			if i % 50 ==0:
+			if i % 50 == 0:
 				sys.stdout.write("Rendering image")
 			elif i % 2 == 0:
 				sys.stdout.write(".")
 				sys.stdout.flush()
 			elif i % 50 == 49:
-				sys.stdout.write("%5.1f%%\n" % (100*i/t))
-			i +=1
+				sys.stdout.write("%5.1f%%\n" % (100 * i / t))
+			i += 1
 			chunkmap = get_map(chunk)
-			x,z = chunk.get_coords()
-			map.paste(chunkmap, (16*(x-bb.minx),16*(z-bb.minz)))
+			x, z = chunk.get_coords()
+			map.paste(chunkmap, (16 * (x - bb.minx), 16 * (z - bb.minz)))
 		print(" done\n")
-		filename = os.path.basename(world_folder)+".png"
-		map.save(filename,"PNG")
+		filename = os.path.basename(world_folder) + ".png"
+		map.save(filename, "PNG")
 		print("Saved map as %s" % filename)
 	except KeyboardInterrupt:
 		print(" aborted\n")
-		filename = os.path.basename(world_folder)+".partial.png"
-		map.save(filename,"PNG")
+		filename = os.path.basename(world_folder) + ".partial.png"
+		map.save(filename, "PNG")
 		print("Saved map as %s" % filename)
-		return 75 # EX_TEMPFAIL
+		return 75  # EX_TEMPFAIL
 	if show:
 		map.show()
-	return 0 # NOERR
+	return 0  # NOERR
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified!")
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	if sys.argv[1] == '--noshow' and len(sys.argv) > 2:
 		show = False
 		world_folder = sys.argv[2]
@@ -219,7 +231,7 @@ if __name__ == '__main__':
 		show = True
 		world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+
 	sys.exit(main(world_folder, show))

--- a/examples/mob_analysis.py
+++ b/examples/mob_analysis.py
@@ -3,36 +3,40 @@
 Finds and prints different entities in a game file, including mobs, items, and vehicles.
 """
 
-import locale, os, sys
+import locale
+import os
+import sys
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 from nbt.world import WorldFolder
 
+
 class Position(object):
-	def __init__(self, x,y,z):
+	def __init__(self, x, y, z):
 		self.x = x
 		self.y = y
 		self.z = z
 
+
 class Entity(object):
 	def __init__(self, type, pos):
-		self.type  = type
-		self.pos   = Position(*pos)
+		self.type = type
+		self.pos = Position(*pos)
 
 
 def entities_per_chunk(chunk):
 	"""Given a chunk, find all entities (mobs, items, vehicles)"""
 	entities = []
 	for entity in chunk['Entities']:
-		x,y,z = entity["Pos"]
-		entities.append(Entity(entity["id"].value, (x.value,y.value,z.value)))
+		x, y, z = entity["Pos"]
+		entities.append(Entity(entity["id"].value, (x.value, y.value, z.value)))
 	return entities
 
 
@@ -41,30 +45,30 @@ def print_results(entities):
 	for entity in entities:
 		print("%s at %s,%s,%s" % \
 			(entity.type,\
-			locale.format("%0.1f",entity.pos.x,grouping=True),\
-			locale.format("%0.1f",entity.pos.y,grouping=True),\
-			locale.format("%0.1f",entity.pos.z,grouping=True)))
+			locale.format("%0.1f", entity.pos.x, grouping=True),\
+			locale.format("%0.1f", entity.pos.y, grouping=True),\
+			locale.format("%0.1f", entity.pos.z, grouping=True)))
 
 
 def main(world_folder):
 	world = WorldFolder(world_folder)
-	
+
 	try:
 		for chunk in world.iter_nbt():
 			print_results(entities_per_chunk(chunk["Level"]))
 
 	except KeyboardInterrupt:
-		return 75 # EX_TEMPFAIL
-	return 0 # NOERR
+		return 75  # EX_TEMPFAIL
+	return 0  # NOERR
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified!")
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+
 	sys.exit(main(world_folder))

--- a/examples/seed.py
+++ b/examples/seed.py
@@ -3,33 +3,35 @@
 Prints the seed of a world.
 """
 
-import os, sys
+import sys
+import os
 
 # local module
 try:
 	import nbt
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 from nbt.nbt import NBTFile
 
+
 def main(world_folder):
-	filename = os.path.join(world_folder,'level.dat')
+	filename = os.path.join(world_folder, 'level.dat')
 	level = NBTFile(filename)
 	print(level["Data"]["RandomSeed"])
-	return 0 # NOERR
+	return 0  # NOERR
 
 
 if __name__ == '__main__':
 	if (len(sys.argv) == 1):
 		print("No world folder specified!")
-		sys.exit(64) # EX_USAGE
+		sys.exit(64)  # EX_USAGE
 	world_folder = sys.argv[1]
 	if (not os.path.exists(world_folder)):
-		print("No such folder as "+world_folder)
-		sys.exit(72) # EX_IOERR
-	
+		print("No such folder as " + world_folder)
+		sys.exit(72)  # EX_IOERR
+
 	sys.exit(main(world_folder))

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -11,11 +11,12 @@ try:
 	from nbt import *
 except ImportError:
 	# nbt not in search path. Let's see if it can be found in the parent folder
-	extrasearchpath = os.path.realpath(os.path.join(__file__,os.pardir,os.pardir))
-	if not os.path.exists(os.path.join(extrasearchpath,'nbt')):
+	extrasearchpath = os.path.realpath(os.path.join(__file__, os.pardir, os.pardir))
+	if not os.path.exists(os.path.join(extrasearchpath, 'nbt')):
 		raise
 	sys.path.append(extrasearchpath)
 	from nbt import *
+
 
 def unpack_nbt(tag):
 	"""
@@ -28,6 +29,7 @@ def unpack_nbt(tag):
 		return dict((i.name, unpack_nbt(i)) for i in tag.tags)
 	else:
 		return tag.value
+
 
 def pack_nbt(s):
 	"""

--- a/nbt/__init__.py
+++ b/nbt/__init__.py
@@ -5,8 +5,9 @@ from . import *
 # If you add more functions, please manually include them in doc/index.rst.
 
 VERSION = (1, 3)
-"""NBT version as tuple. The version currently only contains major and minor 
+"""NBT version as tuple. The version currently only contains major and minor
 revision number, but not (yet) patch and build identifiers."""
+
 
 def _get_version():
 	"""Return the NBT version as string."""

--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -3,23 +3,24 @@ Handles a single chunk of data (16x16x128 blocks) from a Minecraft save.
 Chunk is currently McRegion only.
 """
 from io import BytesIO
-from struct import pack, unpack
-import array, math
+from struct import pack
+import array
+
 
 class Chunk(object):
 	"""Class for representing a single chunk."""
 	def __init__(self, nbt):
 		chunk_data = nbt['Level']
-		self.coords = chunk_data['xPos'],chunk_data['zPos']
+		self.coords = chunk_data['xPos'], chunk_data['zPos']
 		self.blocks = BlockArray(chunk_data['Blocks'].value, chunk_data['Data'].value)
 
 	def get_coords(self):
 		"""Return the coordinates of this chunk."""
-		return (self.coords[0].value,self.coords[1].value)
+		return (self.coords[0].value, self.coords[1].value)
 
 	def __repr__(self):
 		"""Return a representation of this Chunk."""
-		return "Chunk("+str(self.coords[0])+","+str(self.coords[1])+")"
+		return "Chunk(%s,%s)" % (self.coords[0], self.coords[1])
 
 
 class BlockArray(object):
@@ -29,12 +30,12 @@ class BlockArray(object):
 		if isinstance(blocksBytes, (bytearray, array.array)):
 			self.blocksList = list(blocksBytes)
 		else:
-			self.blocksList = [0]*32768 # Create an empty block list (32768 entries of zero (air))
+			self.blocksList = [0] * 32768  # Create an empty block list (32768 entries of zero (air))
 
 		if isinstance(dataBytes, (bytearray, array.array)):
 			self.dataList = list(dataBytes)
 		else:
-			self.dataList = [0]*16384 # Create an empty data list (32768 4-bit entries of zero make 16384 byte entries)
+			self.dataList = [0] * 16384  # Create an empty data list (32768 4-bit entries of zero make 16384 byte entries)
 
 	# Get all block entries
 	def get_all_blocks(self):
@@ -49,8 +50,8 @@ class BlockArray(object):
 			# The first byte of the Blocks arrays correspond
 			# to the LEAST significant bits of the first byte of the Data.
 			# NOT to the MOST significant bits, as you might expected.
-			bits.append(b & 15) # Little end of the byte
-			bits.append((b >> 4) & 15) # Big end of the byte
+			bits.append(b & 15)  # Little end of the byte
+			bits.append((b >> 4) & 15)  # Big end of the byte
 		return bits
 
 	# Get all block entries and data entries as tuples
@@ -65,7 +66,7 @@ class BlockArray(object):
 		cur_z = 0
 		blocks = {}
 		for block_id in self.blocksList:
-			blocks[(cur_x,cur_y,cur_z)] = block_id
+			blocks[(cur_x, cur_y, cur_z)] = block_id
 			cur_y += 1
 			if (cur_y > 127):
 				cur_y = 0
@@ -80,7 +81,7 @@ class BlockArray(object):
 		"""Return a list of all blocks in this chunk."""
 		if buffer:
 			length = len(self.blocksList)
-			return BytesIO(pack(">i", length)+self.get_blocks_byte_array())
+			return BytesIO(pack(">i", length) + self.get_blocks_byte_array())
 		else:
 			return array.array('B', self.blocksList).tostring()
 
@@ -88,7 +89,7 @@ class BlockArray(object):
 		"""Return a list of data for all blocks in this chunk."""
 		if buffer:
 			length = len(self.dataList)
-			return BytesIO(pack(">i", length)+self.get_data_byte_array())
+			return BytesIO(pack(">i", length) + self.get_data_byte_array())
 		else:
 			return array.array('B', self.dataList).tostring()
 
@@ -96,15 +97,15 @@ class BlockArray(object):
 		"""Return a heightmap, representing the highest solid blocks in this chunk."""
 		non_solids = [0, 8, 9, 10, 11, 38, 37, 32, 31]
 		if buffer:
-			return BytesIO(pack(">i", 256)+self.generate_heightmap()) # Length + Heightmap, ready for insertion into Chunk NBT
+			return BytesIO(pack(">i", 256) + self.generate_heightmap())  # Length + Heightmap, ready for insertion into Chunk NBT
 		else:
 			bytes = []
 			for z in range(16):
 				for x in range(16):
 					for y in range(127, -1, -1):
-						offset = y + z*128 + x*128*16
+						offset = y + z * 128 + x * 128 * 16
 						if (self.blocksList[offset] not in non_solids or y == 0):
-							bytes.append(y+1)
+							bytes.append(y + 1)
 							break
 			if (as_array):
 				return bytes
@@ -113,7 +114,7 @@ class BlockArray(object):
 
 	def set_blocks(self, list=None, dict=None, fill_air=False):
 		"""
-		Sets all blocks in this chunk, using either a list or dictionary.  
+		Sets all blocks in this chunk, using either a list or dictionary.
 		Blocks not explicitly set can be filled to air by setting fill_air to True.
 		"""
 		if list:
@@ -125,45 +126,45 @@ class BlockArray(object):
 			for x in range(16):
 				for z in range(16):
 					for y in range(128):
-						coord = x,y,z
-						offset = y + z*128 + x*128*16
+						coord = x, y, z
+						offset = y + z * 128 + x * 128 * 16
 						if (coord in dict):
 							list.append(dict[coord])
 						else:
 							if (self.blocksList[offset] and not fill_air):
 								list.append(self.blocksList[offset])
 							else:
-								list.append(0) # Air
+								list.append(0)  # Air
 			self.blocksList = list
 		else:
 			# None of the above...
 			return False
 		return True
 
-	def set_block(self, x,y,z, id, data=0):
+	def set_block(self, x, y, z, id, data=0):
 		"""Sets the block a x, y, z to the specified id, and optionally data."""
-		offset = y + z*128 + x*128*16
+		offset = y + z * 128 + x * 128 * 16
 		self.blocksList[offset] = id
 		if (offset % 2 == 1):
 			# offset is odd
-			index = (offset-1)//2
+			index = (offset - 1) // 2
 			b = self.dataList[index]
-			self.dataList[index] = (b & 240) + (data & 15) # modify lower bits, leaving higher bits in place
+			self.dataList[index] = (b & 240) + (data & 15)  # modify lower bits, leaving higher bits in place
 		else:
 			# offset is even
-			index = offset//2
+			index = offset // 2
 			b = self.dataList[index]
-			self.dataList[index] = (b & 15) + (data << 4 & 240) # modify ligher bits, leaving lower bits in place
+			self.dataList[index] = (b & 15) + (data << 4 & 240)  # modify ligher bits, leaving lower bits in place
 
 	# Get a given X,Y,Z or a tuple of three coordinates
-	def get_block(self, x,y,z, coord=False):
+	def get_block(self, x, y, z, coord=False):
 		"""Return the id of the block at x, y, z."""
 		"""
 		Laid out like:
 		(0,0,0), (0,1,0), (0,2,0) ... (0,127,0), (0,0,1), (0,1,1), (0,2,1) ... (0,127,1), (0,0,2) ... (0,127,15), (1,0,0), (1,1,0) ... (15,127,15)
-		
+
 		::
-		
+
 		  blocks = []
 		  for x in range(15):
 		    for z in range(15):
@@ -171,28 +172,27 @@ class BlockArray(object):
 		        blocks.append(Block(x,y,z))
 		"""
 
-		offset = y + z*128 + x*128*16 if (coord == False) else coord[1] + coord[2]*128 + coord[0]*128*16
+		offset = y + z * 128 + x * 128 * 16 if (coord == False) else coord[1] + coord[2] * 128 + coord[0] * 128 * 16
 		return self.blocksList[offset]
 
 	# Get a given X,Y,Z or a tuple of three coordinates
-	def get_data(self, x,y,z, coord=False):
+	def get_data(self, x, y, z, coord=False):
 		"""Return the data of the block at x, y, z."""
-		offset = y + z*128 + x*128*16 if (coord == False) else coord[1] + coord[2]*128 + coord[0]*128*16
+		offset = y + z * 128 + x * 128 * 16 if (coord == False) else coord[1] + coord[2] * 128 + coord[0] * 128 * 16
 		# The first byte of the Blocks arrays correspond
 		# to the LEAST significant bits of the first byte of the Data.
 		# NOT to the MOST significant bits, as you might expected.
 		if (offset % 2 == 1):
 			# offset is odd
-			index = (offset-1)//2
+			index = (offset - 1) // 2
 			b = self.dataList[index]
-			return b & 15 # Get little (last 4 bits) end of byte
+			return b & 15  # Get little (last 4 bits) end of byte
 		else:
 			# offset is even
-			index = offset//2
+			index = offset // 2
 			b = self.dataList[index]
-			return (b >> 4) & 15 # Get big end (first 4 bits) of byte
+			return (b >> 4) & 15  # Get big end (first 4 bits) of byte
 
-	def get_block_and_data(self, x,y,z, coord=False):
+	def get_block_and_data(self, x, y, z, coord=False):
 		"""Return the tuple of (id, data) for the block at x, y, z"""
-		return (self.get_block(x,y,z,coord),self.get_data(x,y,z,coord))
-
+		return (self.get_block(x, y, z, coord), self.get_data(x, y, z, coord))

--- a/nbt/world.py
+++ b/nbt/world.py
@@ -2,7 +2,9 @@
 Handles a Minecraft world save using either the Anvil or McRegion format.
 """
 
-import os, glob, re
+import glob
+import os
+import re
 from . import region
 from . import chunk
 
@@ -11,6 +13,7 @@ class UnknownWorldFormat(Exception):
 	"""Unknown or invalid world folder."""
 	def __init__(self, msg):
 		self.msg = msg
+
 
 class InconceivedChunk(LookupError):
 	"""Specified chunk has not yet been generated"""
@@ -28,8 +31,8 @@ class _BaseWorldFolder(object):
 		"""Initialize a WorldFolder."""
 		self.worldfolder = world_folder
 		self.regionfiles = {}
-		self.regions	 = {}
-		self.chunks	 = None
+		self.regions = {}
+		self.chunks = None
 		# os.listdir triggers an OSError for non-existant directories or permission errors.
 		# This is needed, because glob.glob silently returns no files.
 		os.listdir(world_folder)
@@ -37,7 +40,7 @@ class _BaseWorldFolder(object):
 
 	def get_filenames(self):
 		# Warning: glob returns a empty list if the directory is unreadable, without raising an Exception
-		return list(glob.glob(os.path.join(self.worldfolder,'region','r.*.*.'+self.extension)))
+		return list(glob.glob(os.path.join(self.worldfolder, 'region', 'r.*.*.' + self.extension)))
 
 	def set_regionfiles(self, filenames):
 		"""
@@ -46,7 +49,7 @@ class _BaseWorldFolder(object):
 		"""
 		for filename in filenames:
 			# Assume that filenames have the name r.<x-digit>.<z-digit>.<extension>
-			m = re.match(r"r.(\-?\d+).(\-?\d+)."+self.extension, os.path.basename(filename))
+			m = re.match(r"r.(\-?\d+).(\-?\d+)." + self.extension, os.path.basename(filename))
 			if m:
 				x = int(m.group(1))
 				z = int(m.group(2))
@@ -59,7 +62,7 @@ class _BaseWorldFolder(object):
 				# raise UnknownWorldFormat("Unrecognized filename format %s" % os.path.basename(filename))
 				# TODO: log to stderr using logging facility.
 				pass
-			self.regionfiles[(x,z)] = filename
+			self.regionfiles[(x, z)] = filename
 
 	def nonempty(self):
 		"""Return True is the world is non-empty."""
@@ -69,20 +72,20 @@ class _BaseWorldFolder(object):
 		"""Return a list of full path of all region files."""
 		return list(self.regionfiles.values())
 
-	def get_region(self, x,z):
-		"""Get a region using x,z coordinates of a region. Cache results."""
-		if (x,z) not in self.regions:
-			if (x,z) in self.regionfiles:
-				self.regions[(x,z)] = region.RegionFile(self.regionfiles[(x,z)])
+	def get_region(self, x, z):
+		"""Get a region using x, z coordinates of a region. Cache results."""
+		if (x, z) not in self.regions:
+			if (x, z) in self.regionfiles:
+				self.regions[(x, z)] = region.RegionFile(self.regionfiles[(x, z)])
 			else:
 				# Return an empty RegionFile object
 				# TODO: this does not yet allow for saving of the region file
-				self.regions[(x,z)] = region.RegionFile()
-		return self.regions[(x,z)]
+				self.regions[(x, z)] = region.RegionFile()
+		return self.regions[(x, z)]
 
 	def iter_regions(self):
-		for x,z in self.regionfiles.keys():
-			yield self.get_region(x,z)
+		for x, z in self.regionfiles.keys():
+			yield self.get_region(x, z)
 
 	def iter_nbt(self):
 		"""
@@ -108,19 +111,19 @@ class _BaseWorldFolder(object):
 		for c in self.iter_nbt():
 			yield chunk.Chunk(c)
 
-	def get_nbt(self,x,z):
+	def get_nbt(self, x, z):
 		"""
 		Return a NBT specified by the chunk coordinates x,z. Raise InconceivedChunk
 		if the NBT file is not yet generated. To get a Chunk object, use get_chunk.
 		"""
-		rx,x = divmod(x,32)
-		rz,z = divmod(z,32)
-		nbt = self.get_region(rx,rz).get_chunk(x,z)
+		rx, x = divmod(x, 32)
+		rz, z = divmod(z, 32)
+		nbt = self.get_region(rx, rz).get_chunk(x, z)
 		if nbt == None:
-			raise InconceivedChunk("Chunk %s,%s not present in world" % (32*rx+x,32*rz+z))
+			raise InconceivedChunk("Chunk %s,%s not present in world" % (32 * rx + x, 32 * rz + z))
 		return nbt
 
-	def set_nbt(self,x,z,nbt):
+	def set_nbt(self, x, z, nbt):
 		"""
 		Set a chunk. Overrides the NBT if it already existed. If the NBT did not exists,
 		adds it to the Regionfile. May create a new Regionfile if that did not exist yet.
@@ -129,7 +132,7 @@ class _BaseWorldFolder(object):
 		raise NotImplemented()
 		# TODO: implement
 
-	def get_chunk(self,x,z):
+	def get_chunk(self, x, z):
 		"""
 		Return a chunk specified by the chunk coordinates x,z. Raise InconceivedChunk
 		if the chunk is not yet generated. To get the raw NBT data, use get_nbt.
@@ -160,12 +163,12 @@ class _BaseWorldFolder(object):
 		make up this world save
 		"""
 		b = BoundingBox()
-		for rx,rz in self.regionfiles.keys():
-			region = self.get_region(rx,rz)
-			rx,rz = 32*rx,32*rz
+		for rx, rz in self.regionfiles.keys():
+			region = self.get_region(rx, rz)
+			rx, rz = 32 * rx, 32 * rz
 			for cc in region.get_chunk_coords():
-				x,z = (rx+cc['x'],rz+cc['z'])
-				b.expand(x,None,z)
+				x, z = (rx + cc['x'], rz + cc['z'])
+				b.expand(x, None, z)
 		return b
 
 	def cache_test(self):
@@ -175,21 +178,21 @@ class _BaseWorldFolder(object):
 		"""
 		# TODO: make sure this test succeeds (at least True,True,False, preferable True,True,True)
 		# TODO: Move this function to test class.
-		for rx,rz in self.regionfiles.keys():
-			region = self.get_region(rx,rz)
-			rx,rz = 32*rx,32*rz
+		for rx, rz in self.regionfiles.keys():
+			region = self.get_region(rx, rz)
+			rx, rz = 32 * rx, 32 * rz
 			for cc in region.get_chunk_coords():
-				x,z = (rx+cc['x'],rz+cc['z'])
-				c1 = self.chunkclass(region.get_chunk(cc['x'],cc['z']))
-				c2 = self.get_chunk(x,z)
-				correct_coords = (c2.get_coords() == (x,z))
-				is_comparable = (c1 == c2) # test __eq__ function
-				is_equal = (id(c1) == id(c2)) # test if they point to the same memory location
+				x, z = (rx + cc['x'], rz + cc['z'])
+				c1 = self.chunkclass(region.get_chunk(cc['x'], cc['z']))
+				c2 = self.get_chunk(x, z)
+				correct_coords = (c2.get_coords() == (x, z))
+				is_comparable = (c1 == c2)  # test __eq__ function
+				is_equal = (id(c1) == id(c2))  # test if they point to the same memory location
 				# DEBUG (prints a tuple)
-				print((x,z,c1,c2,correct_coords,is_comparable,is_equal))
+				print((x, z, c1, c2, correct_coords, is_comparable, is_equal))
 
 	def __repr__(self):
-		return "%s(%r)" % (self.__class__.__name__,self.worldfolder)
+		return "%s(%r)" % (self.__class__.__name__, self.worldfolder)
 
 
 class McRegionWorldFolder(_BaseWorldFolder):
@@ -198,6 +201,7 @@ class McRegionWorldFolder(_BaseWorldFolder):
 	extension = 'mcr'
 	chunkclass = chunk.Chunk
 	# chunkclass = chunk.McRegionChunk  # TODO: change to McRegionChunk when done
+
 
 class AnvilWorldFolder(_BaseWorldFolder):
 	"""Represents a world save using the new Anvil format."""
@@ -208,17 +212,18 @@ class AnvilWorldFolder(_BaseWorldFolder):
 
 
 class _WorldFolderFactory():
-	"""Factory class: instantiate the subclassses in order, and the first instance 
+	"""Factory class: instantiate the subclassses in order, and the first instance
 	whose nonempty() method returns True is returned. If no nonempty() returns True,
 	a UnknownWorldFormat exception is raised."""
 	def __init__(self, subclasses):
 		self.subclasses = subclasses
+
 	def __call__(self, *args, **kwargs):
 		for cls in self.subclasses:
 			wf = cls(*args, **kwargs)
-			if wf.nonempty(): # Check if the world is non-empty
+			if wf.nonempty():  # Check if the world is non-empty
 				return wf
-		raise UnknownWorldFormat("Empty world or unknown format: %r" % world_folder)
+		raise UnknownWorldFormat("Empty world or unknown format: %r" % (args, kwargs))
 
 WorldFolder = _WorldFolderFactory([AnvilWorldFolder, McRegionWorldFolder])
 """
@@ -227,14 +232,14 @@ instance, or raise a UnknownWorldFormat.
 """
 
 
-
 class BoundingBox(object):
 	"""A bounding box of x,y,z coordinates."""
 	def __init__(self, minx=None, maxx=None, miny=None, maxy=None, minz=None, maxz=None):
-		self.minx,self.maxx = minx, maxx
-		self.miny,self.maxy = miny, maxy
-		self.minz,self.maxz = minz, maxz
-	def expand(self,x,y,z):
+		self.minx, self.maxx = minx, maxx
+		self.miny, self.maxy = miny, maxy
+		self.minz, self.maxz = minz, maxz
+
+	def expand(self, x, y, z):
 		"""
 		Expands the bounding
 		"""
@@ -253,12 +258,16 @@ class BoundingBox(object):
 				self.minz = z
 			if self.maxz is None or z > self.maxz:
 				self.maxz = z
+
 	def lenx(self):
-		return self.maxx-self.minx+1
+		return self.maxx - self.minx + 1
+
 	def leny(self):
-		return self.maxy-self.miny+1
+		return self.maxy - self.miny + 1
+
 	def lenz(self):
-		return self.maxz-self.minz+1
+		return self.maxz - self.minz + 1
+
 	def __repr__(self):
-		return "%s(%s,%s,%s,%s,%s,%s)" % (self.__class__.__name__,self.minx,self.maxx,
-				self.miny,self.maxy,self.minz,self.maxz)
+		return "%s(%s,%s,%s,%s,%s,%s)" % (self.__class__.__name__, self.minx, self.maxx,
+				self.miny, self.maxy, self.minz, self.maxz)

--- a/tests/alltests.py
+++ b/tests/alltests.py
@@ -23,8 +23,7 @@ def get_testsuites_in_module(module):
 
 def load_tests_in_modules(modulenames):
 	"""
-	Given a list of module names, import the modules, load and run the 
-	test cases in these modules. The modules are typically files in the 
+	Given a list of module names, import the modules, load and run the 	test cases in these modules. The modules are typically files in the
 	current directory, but this is not a requirement.
 	"""
 	loader = unittest.TestLoader()
@@ -38,7 +37,6 @@ def load_tests_in_modules(modulenames):
 		suites.append(suite)
 	suite = unittest.TestSuite(suites)
 	return suite
-
 
 
 if __name__ == "__main__":

--- a/tests/downloadsample.py
+++ b/tests/downloadsample.py
@@ -25,21 +25,21 @@ workdir = os.path.dirname(__file__)
 worlddir = os.path.join(workdir, 'Sample World')
 """Destination folder for the sample world."""
 checksums = {
-	'Sample World': None, 
-	'Sample World/data': None, 
-	'Sample World/level.dat': 'f252cf8b938fa1e41c9335ea1bdc70fca73ac5c63c2cf2db4b2ddc4cb2fa4d91', 
-	'Sample World/level.dat_mcr': '933238e89a9f7f94c72f236da0d81d44d966c7a1544490e51e682ab42ccc50ff', 
-	'Sample World/level.dat_old': 'c4b5a5c355d4f85c369604ca27ee349dba41adc4712a43a6f8c8399fe44071e7', 
-	'Sample World/region': None, 
-	'Sample World/region/r.-1.0.mca': '6e8ec8698e2e68ca3ee2090da72e4f24c85f9db3f36191e5e33ebc8cafb209f2', 
-	'Sample World/region/r.-1.0.mcr': '3a9ccafc6f64b98c0424814f44f1d0d3429cbb33448ff97e2e84ca649bfa16ae', 
-	'Sample World/region/r.-1.1.mca': 'c5f6fb5c72ca534d0f73662f2199dca977d2de1521b4823f73384aa6826c4b74', 
-	'Sample World/region/r.-1.1.mcr': '8e8b545b412a6a2bb519aee0259a63e6a918cd25a49538451e752e3bf90d4cf1', 
-	'Sample World/region/r.0.0.mca': 'd86e51c2adf35f82492e974f75fe83e9e5db56a267a3fe76150dc42f0aeb07c7', 
-	'Sample World/region/r.0.0.mcr': 'a8e7fea4e40a70e0d70dea7ebb1328c7623ed01b77d8aff34d01e530fbdad9d5', 
-	'Sample World/region/r.0.1.mca': '8a03d910c7fd185ae5efb1409c592e4a9688dfab1fbd31f8c736461157a7675d', 
-	'Sample World/region/r.0.1.mcr': '08fcd50748d4633a3b1d52e1b323c7dd9c4299a28ec095d0261fd195d3c9a537', 
-	'Sample World/session.lock': 'd05da686dd04cd2ad1f660ddaa7645abc9fd9af396357a5b3256b437af0d7dba', 
+	'Sample World': None,
+	'Sample World/data': None,
+	'Sample World/level.dat': 'f252cf8b938fa1e41c9335ea1bdc70fca73ac5c63c2cf2db4b2ddc4cb2fa4d91',
+	'Sample World/level.dat_mcr': '933238e89a9f7f94c72f236da0d81d44d966c7a1544490e51e682ab42ccc50ff',
+	'Sample World/level.dat_old': 'c4b5a5c355d4f85c369604ca27ee349dba41adc4712a43a6f8c8399fe44071e7',
+	'Sample World/region': None,
+	'Sample World/region/r.-1.0.mca': '6e8ec8698e2e68ca3ee2090da72e4f24c85f9db3f36191e5e33ebc8cafb209f2',
+	'Sample World/region/r.-1.0.mcr': '3a9ccafc6f64b98c0424814f44f1d0d3429cbb33448ff97e2e84ca649bfa16ae',
+	'Sample World/region/r.-1.1.mca': 'c5f6fb5c72ca534d0f73662f2199dca977d2de1521b4823f73384aa6826c4b74',
+	'Sample World/region/r.-1.1.mcr': '8e8b545b412a6a2bb519aee0259a63e6a918cd25a49538451e752e3bf90d4cf1',
+	'Sample World/region/r.0.0.mca': 'd86e51c2adf35f82492e974f75fe83e9e5db56a267a3fe76150dc42f0aeb07c7',
+	'Sample World/region/r.0.0.mcr': 'a8e7fea4e40a70e0d70dea7ebb1328c7623ed01b77d8aff34d01e530fbdad9d5',
+	'Sample World/region/r.0.1.mca': '8a03d910c7fd185ae5efb1409c592e4a9688dfab1fbd31f8c736461157a7675d',
+	'Sample World/region/r.0.1.mcr': '08fcd50748d4633a3b1d52e1b323c7dd9c4299a28ec095d0261fd195d3c9a537',
+	'Sample World/session.lock': 'd05da686dd04cd2ad1f660ddaa7645abc9fd9af396357a5b3256b437af0d7dba',
 }
 """SHA256 checksums for each file in the tar file.
 Directories MUST also be included (without trailing slash), with None as the checksum"""
@@ -48,7 +48,7 @@ Directories MUST also be included (without trailing slash), with None as the che
 def download(url, destination):
 	"""
 	Download the file from the specified URL, and extract the contents.
-	
+
 	May raise an IOError (or one of it's subclasses) upon error, either
 	in reading from the URL of writing to file.
 	"""
@@ -60,14 +60,15 @@ def download(url, destination):
 		remotefile = urllib.urlopen(request)
 		localfile = open(destination, 'wb')
 		logger.info("Downloading %s" % url)
-		chunksize = 524288 # 0.5 MiB
+		chunksize = 524288  # 0.5 MiB
 		size = 0
 		while True:
 			data = remotefile.read(chunksize)
-			if not data: break
+			if not data:
+				break
 			localfile.write(data)
 			size += len(data)
-			logging.info("Downloaded %0.1f MiByte..." % (float(size)/1048576))
+			logging.info("Downloaded %0.1f MiByte..." % (float(size) / 1048576))
 	finally:
 		try:
 			remotefile.close()
@@ -76,16 +77,18 @@ def download(url, destination):
 			pass
 	logging.info("Download complete")
 
+
 def extract(filename, workdir, filelist):
 	"""
-	Extract contents of a tar file in workdir. The tar file may be compressed 
+	Extract contents of a tar file in workdir. The tar file may be compressed
 	using gzip or bzip2.
-	
+
 	For security, only files listed in filelist are extracted.
 	Extraneous files will be logged as warning.
 	"""
 	logger = logging.getLogger("nbt.tests.downloadsample")
 	logger.info("Extracting")
+
 	def filefilter(members):
 		for tarinfo in members:
 			if tarinfo.name in filelist:
@@ -101,14 +104,14 @@ def extract(filename, workdir, filelist):
 
 def verify(checksums):
 	"""
-	Verify if all given files are present and their SHA256 
+	Verify if all given files are present and their SHA256
 	checksum is correct. Any files not explicitly listed are deleted.
-	
+
 	checksums is a dict of file => checksum, with file a file relative to dir.
-	
-	Returns a boolean indicating that all checksums are correct, and all files 
+
+	Returns a boolean indicating that all checksums are correct, and all files
 	are present.
-	
+
 	Any warnings and errors are printer to logger.
 	Errors or exceptions result in a return value of False.
 	"""
@@ -117,13 +120,15 @@ def verify(checksums):
 	for path in checksums.keys():
 		try:
 			check = checksums[path]
-			if check == None: continue  # Skip folders
+			if check == None:
+				continue  # Skip folders
 			localfile = open(path, 'rb')
 			h = hashlib.sha256()
-			chunksize = 524288 # 0.5 MiB
+			chunksize = 524288  # 0.5 MiB
 			while True:
 				data = localfile.read(chunksize)
-				if not data: break
+				if not data:
+					break
 				h.update(data)
 			localfile.close()
 			calc = h.hexdigest()
@@ -145,11 +150,11 @@ def install(url=URL, workdir=workdir, checksums=checksums):
 	"""
 	Download and extract a sample world, used for testing.
 	The download file and sample world are stored in workdir.
-	
+
 	Verifies the checksum of all files. Files without a checksum are not
 	extracted.
 	"""
-	# the paths in checksum are relative to the working dir, and UNIX-based. 
+	# the paths in checksum are relative to the working dir, and UNIX-based.
 	# Normalise them to support Windows; and create the following three derivates:
 	# - posixpaths: list of relative posix paths -- to filter tar extraction
 	# - nchecksums: as checksum, but with normalised absolute paths
@@ -159,7 +164,7 @@ def install(url=URL, workdir=workdir, checksums=checksums):
 			for path in posixpaths if checksums[path] != None])
 	files = nchecksums.keys()
 	tarfile = os.path.join(workdir, os.path.basename(url))
-	
+
 	try:
 		if not any(map(os.path.exists, files)):
 			# none destination file exists. We can safely download/extract without overwriting.
@@ -180,37 +185,45 @@ def install(url=URL, workdir=workdir, checksums=checksums):
 	return False
 
 
-
 def _mkdir(dstdir, subdir):
 	"""Helper function: create folder /dstdir/subdir"""
 	os.mkdir(os.path.join(dstdir, os.path.normpath(subdir)))
+
+
 def _copyglob(srcdir, destdir, pattern):
 	"""Helper function: copies files from /srcdir/pattern to /destdir/pattern.
 	pattern is a glob pattern."""
 	for fullpath in glob.glob(os.path.join(srcdir, os.path.normpath(pattern))):
 		relpath = os.path.relpath(fullpath, srcdir)
 		shutil.copy2(fullpath, os.path.join(destdir, relpath))
+
+
 def _copyrename(srcdir, destdir, src, dest):
 	"""Helper function: copy file from /srcdir/src to /destdir/dest."""
 	shutil.copy2(os.path.join(srcdir, os.path.normpath(src)), \
 				os.path.join(destdir, os.path.normpath(dest)))
 
+
 def temp_mcregion_world(worldfolder=worlddir):
-	"""Create a McRegion worldfolder in a temporary directory, based on the 
+	"""Create a McRegion worldfolder in a temporary directory, based on the
 	files in the given mixed worldfolder. Returns the temporary directory path."""
 	tmpfolder = tempfile.mkdtemp(prefix="nbtmcregion")
 	_mkdir(tmpfolder, 'region')
 	_copyglob(worldfolder, tmpfolder, "region/*.mcr")
 	_copyrename(worldfolder, tmpfolder, "level.dat_mcr", "level.dat")
 	return tmpfolder
+
+
 def temp_anvil_world(worldfolder=worlddir):
-	"""Create a Anvil worldfolder in a temporary directory, based on the 
+	"""Create a Anvil worldfolder in a temporary directory, based on the
 	files in the given mixed worldfolder. Returns the temporary directory path."""
 	tmpfolder = tempfile.mkdtemp(prefix="nbtanvil")
 	_mkdir(tmpfolder, 'region')
 	_copyglob(worldfolder, tmpfolder, "region/*.mca")
 	_copyrename(worldfolder, tmpfolder, "level.dat", "level.dat")
 	return tmpfolder
+
+
 def cleanup_temp_world(tmpfolder):
 	"""Remove a temporary directory"""
 	shutil.rmtree(tmpfolder, ignore_errors=True)

--- a/tests/examplestests.py
+++ b/tests/examplestests.py
@@ -9,7 +9,6 @@ import os
 import unittest
 import subprocess
 import shutil
-import tempfile
 import glob
 # local modules
 import downloadsample
@@ -33,15 +32,20 @@ else:
 		filter = str.maketrans('', '', deletechars)
 		return text.translate(filter)
 
+
 def _mkdir(dstdir, subdir):
 	"""Helper function: create folder /dstdir/subdir"""
 	os.mkdir(os.path.join(dstdir, os.path.normpath(subdir)))
+
+
 def _copyglob(srcdir, destdir, pattern):
 	"""Helper function: copies files from /srcdir/pattern to /destdir/pattern.
 	pattern is a glob pattern."""
 	for fullpath in glob.glob(os.path.join(srcdir, os.path.normpath(pattern))):
 		relpath = os.path.relpath(fullpath, srcdir)
 		shutil.copy2(fullpath, os.path.join(destdir, relpath))
+
+
 def _copyrename(srcdir, destdir, src, dest):
 	"""Helper function: copy file from /srcdir/src to /destdir/dest."""
 	shutil.copy2(os.path.join(srcdir, os.path.normpath(src)), \
@@ -49,12 +53,13 @@ def _copyrename(srcdir, destdir, src, dest):
 
 
 class ScriptTestCase(unittest.TestCase):
-	"""Test Case with helper functions for running a script, and installing a 
+	"""Test Case with helper functions for running a script, and installing a
 	Minecraft sample world."""
 	worldfolder = None
 	mcregionfolder = None
 	anvilfolder = None
 	examplesdir = os.path.normpath(os.path.join(__file__, os.pardir, os.pardir, 'examples'))
+
 	def runScript(self, script, args):
 		scriptpath = os.path.join(self.examplesdir, script)
 		args.insert(0, scriptpath)
@@ -73,14 +78,16 @@ class ScriptTestCase(unittest.TestCase):
 			pass
 		self.assertEqual(p.returncode, 0, "return code is %d" % p.returncode)
 		return output
+
 	def assertEqualOutput(self, actual, expected):
 		"""Compare two lists of strings, ignoring whitespace at begin and end of line."""
 		if len(actual) < len(expected):
 			self.fail("Output is %d lines, expected at least %d lines" % \
 					(len(actual), len(expected)))
-		for i,expline in enumerate(expected):
+		for i, expline in enumerate(expected):
 			self.assertEqual(actual[i].strip(), expline.strip(), \
-					"Output line %d is %r, expected %r" % (i+1, actual[i], expline))
+					"Output line %d is %r, expected %r" % (i + 1, actual[i], expline))
+
 	def assertEqualString(self, actual, expected):
 		"""Compare strings, ignoring whitespace at begin and end of line."""
 		self.assertEqual(actual.strip(), expected.strip(), \
@@ -89,19 +96,20 @@ class ScriptTestCase(unittest.TestCase):
 
 class BiomeAnalysisScriptTest(ScriptTestCase):
 	pass
-	
+
 	# TODO: Sample World was converted with simple script, but does not seem to have biome data.
-	# This needs to be added. (opening the world with minecraft client will change the 
-	# world a bit, which I like to avoid. Perhaps opening with the server will not change it, 
-	# if "/stop" is called quickly enough. this may change the amount of generated chunks to 
+	# This needs to be added. (opening the world with minecraft client will change the
+	# world a bit, which I like to avoid. Perhaps opening with the server will not change it,
+	# if "/stop" is called quickly enough. this may change the amount of generated chunks to
 	# everything in a 380x380 block though.)
-	
+
 	# @classmethod
 	# def setUpClass(cls):
 	# 	cls.installsampleworld()
 	# 	cls.extractAnvilWorld()
 	# def testAnvilWorld(self):
 	# 	output = self.runScript('biome_analysis.py', [self.anvilfolder])
+
 
 class BlockAnalysisScriptTest(ScriptTestCase):
 	expected = [
@@ -122,6 +130,7 @@ class BlockAnalysisScriptTest(ScriptTestCase):
 		"RedMushroom:31",
 		"LavaSprings:47665",
 	]
+
 	def testMcRegionWorld(self):
 		output = self.runScript('block_analysis.py', [self.mcregionfolder])
 		self.assertTrue(len(output) >= 73, "Expected output of at least 73 lines long")
@@ -135,17 +144,20 @@ class BlockAnalysisScriptTest(ScriptTestCase):
 	# 	output = [_deletechars(l, " ,.") for l in output[-16:]]
 	# 	self.assertEqualOutput(output, self.expected)
 
+
 class ChestAnalysisScriptTest(ScriptTestCase):
 	def testMcRegionWorld(self):
 		output = self.runScript('chest_analysis.py', [self.mcregionfolder])
 		self.assertEqual(len(output), 178)
 		count = len(list(filter(lambda l: l.startswith('Chest at '), output)))
 		self.assertEqual(count, 38)
+
 	def testAnvilWorld(self):
 		output = self.runScript('chest_analysis.py', [self.anvilfolder])
 		self.assertEqual(len(output), 178)
 		count = len(list(filter(lambda l: l.startswith('Chest at '), output)))
 		self.assertEqual(count, 38)
+
 
 def has_PIL():
 	try:
@@ -154,18 +166,20 @@ def has_PIL():
 	except ImportError:
 		return False
 
+
 class MapScriptTest(ScriptTestCase):
 	@skipIf(not has_PIL(), "PIL library not available")
 	def testMcRegionWorld(self):
 		output = self.runScript('map.py', ['--noshow', self.mcregionfolder])
 		self.assertTrue(output[-1].startswith("Saved map as "))
-	# TODO: this currently writes the map to tests/nbtmcregion*.png files. 
+	# TODO: this currently writes the map to tests/nbtmcregion*.png files.
 	# The locations should be a tempfile, and the file should be deleted afterwards.
-	
+
 	# @skipIf(not has_PIL(), "PIL library not available")
 	# def testAnvilWorld(self):
 	# 	output = self.runScript('map.py', ['--noshow', self.anvilfolder])
 	# 	self.assertEqualString(output[-1], "Saved map as Sample World.png")
+
 
 class MobAnalysisScriptTest(ScriptTestCase):
 	def testMcRegionWorld(self):
@@ -174,6 +188,7 @@ class MobAnalysisScriptTest(ScriptTestCase):
 		output = sorted(output)
 		self.assertEqualString(output[0], "Chicken at 107.6,88.0,374.5")
 		self.assertEqualString(output[400], "Zombie at 249.3,48.0,368.1")
+
 	def testAnvilWorld(self):
 		output = self.runScript('mob_analysis.py', [self.anvilfolder])
 		self.assertEqual(len(output), 413)
@@ -181,13 +196,16 @@ class MobAnalysisScriptTest(ScriptTestCase):
 		self.assertEqualString(output[0], "Chicken at 107.6,88.0,374.5")
 		self.assertEqualString(output[400], "Zombie at 249.3,48.0,368.1")
 
+
 class SeedScriptTest(ScriptTestCase):
 	def testMcRegionWorld(self):
 		output = self.runScript('seed.py', [self.mcregionfolder])
 		self.assertEqualOutput(output, ["-3195717715052600521"])
+
 	def testAnvilWorld(self):
 		output = self.runScript('seed.py', [self.anvilfolder])
 		self.assertEqualOutput(output, ["-3195717715052600521"])
+
 
 class GenerateLevelDatScriptTest(ScriptTestCase):
 	expected = [
@@ -210,10 +228,11 @@ class GenerateLevelDatScriptTest(ScriptTestCase):
 		"	}",
 		"}"
 	]
+
 	def testNBTGeneration(self):
 		output = self.runScript('generate_level_dat.py', [])
 		self.assertEqual(len(output), 18)
-		self.assertEqualString(output[0],  self.expected[0])
+		self.assertEqualString(output[0], self.expected[0])
 		self.assertEqualString(output[10], self.expected[10])
 		self.assertEqualString(output[11], self.expected[11])
 		self.assertEqualString(output[13], self.expected[13])
@@ -229,6 +248,7 @@ def setUpModule():
 	if ScriptTestCase.anvilfolder == None:
 		ScriptTestCase.anvilfolder = downloadsample.temp_anvil_world()
 
+
 def tearDownModule():
 	"""Remove temporary folders with Anvil and McRegion files."""
 	if ScriptTestCase.mcregionfolder != None:
@@ -240,9 +260,9 @@ def tearDownModule():
 	ScriptTestCase.anvilfolder = None
 
 
-if sys.version_info[0:2] < (2,7):
+if sys.version_info[0:2] < (2, 7):
 	class TestSuite(unittest.TestSuite):
-		"""Test suite which backports the setUpModule/tearDownModule fixture 
+		"""Test suite which backports the setUpModule/tearDownModule fixture
 		to Python 2.6."""
 		def run(self, tests=[]):
 			setUpModule()
@@ -251,7 +271,7 @@ if sys.version_info[0:2] < (2,7):
 
 
 if __name__ == '__main__':
-	if sys.version_info[0:2] >= (2,7):
+	if sys.version_info[0:2] >= (2, 7):
 		unittest.main(verbosity=2, failfast=True, catchbreak=True)
 	else:
 		module = sys.modules[__name__]

--- a/tests/nbttests.py
+++ b/tests/nbttests.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
-import sys,os,unittest
-import tempfile, shutil
+import os
+import shutil
+import sys
+import tempfile
+import unittest
 from io import BytesIO
 from gzip import GzipFile
 
-# Search parent directory first, to make sure we test the local nbt module, 
+# Search parent directory first, to make sure we test the local nbt module,
 # not an installed nbt module.
-parentdir = os.path.realpath(os.path.join(os.path.dirname(__file__),os.pardir))
+parentdir = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
 if parentdir not in sys.path:
 	sys.path.insert(1, parentdir)  # insert ../ just after ./
 
@@ -28,25 +31,26 @@ class BugfixTest(unittest.TestCase):
 
 	def testProperlyClosed(self):
 		"""
-		test that files opened from a file name are closed after 
+		test that files opened from a file name are closed after
 		being written to. i.e. will read correctly in the future
 		"""
 		# copy the file (don't work on the original test file)
 		tempdir = tempfile.mkdtemp()
 		filename = os.path.join(tempdir, 'bigtest.nbt')
 		shutil.copy(NBTTESTFILE, filename)
-		
+
 		#open the file
 		f = NBTFile(filename)
 		f.write_file()
 		# make sure it can be read again directly after
 		f = NBTFile(filename)
-		
+
 		# remove the temporary file
 		try:
 			shutil.rmtree(tempdir)
-		except OSError as e:
+		except OSError:
 			raise
+
 
 class ReadWriteTest(unittest.TestCase):
 	"""test that we can read the test file correctly"""
@@ -59,9 +63,9 @@ class ReadWriteTest(unittest.TestCase):
 	def tearDown(self):
 		try:
 			shutil.rmtree(self.tempdir)
-		except OSError as e:
+		except OSError:
 			raise
-	
+
 	def testReadBig(self):
 		mynbt = NBTFile(self.filename)
 		self.assertTrue(mynbt.filename != None)
@@ -76,6 +80,7 @@ class ReadWriteTest(unittest.TestCase):
 	def testWriteback(self):
 		mynbt = NBTFile(self.filename)
 		mynbt.write_file()
+
 
 class TreeManipulationTest(unittest.TestCase):
 
@@ -98,6 +103,7 @@ class TreeManipulationTest(unittest.TestCase):
 
 	def tearDown(self):
 		del self.nbtfile
+
 
 class EmptyStringTest(unittest.TestCase):
 


### PR DESCRIPTION
Some un-[PEP8](http://www.python.org/dev/peps/pep-0008/)tish code slipped into the code.

Internally we check for such tings automatically and rigurously to minimize whitespace changes and other stuff which otherwises clutters our change sets and makes merging more difficult than it should be.

This patch addresses concerns of:

```
$ pyflakes nbt examples tests
$ pep8 -r --ignore=E501,W191,E101 nbt examples tests
```

It also adds a simple makefile to allow easy checking. Just type `make`.
