### PR TITLE
Fix infinite loop when writing a chunk. Add new exception.

### DIFF
--- a/nbt/region.py
+++ b/nbt/region.py
@@ -12,6 +12,11 @@ from io import BytesIO
 import math, time
 from os.path import getsize
 
+class NoRegionHeader(Exception):
+	"""The size of the region file is too small to contain a header."""
+	def __init__(self, msg):
+		self.msg = msg
+
 class RegionHeaderError(Exception):
 	"""Error in the header of the region file for a given chunk."""
 	def __init__(self, msg):
@@ -94,6 +99,8 @@ class RegionFile(object):
 				# Minecraft handle them without problems. Take them
 				# as empty region files.
 				self.init_header()
+			elif self.size < 8192:
+				raise NoRegionHeader('The region file is too small in size to have a header.')
 			else:
 				self.parse_header()
 		else:


### PR DESCRIPTION
This pull request fixes the infinite loop problem in the write_chunk function in region.py reported in issue #42. For that I have rewritten the function in a simpler form.

Also it adds a new exception that is raised when a file smaller than 8KiB in size is opened. In such a file there is not enough space for the region header and the file is most probably not a region file. Without this exception a very confusing error is thrown.

If there is anything that need changes before merging, please, let me know.
