### PR TITLE
Fix unlink chunk with mismatched lengths status taking minutes

### DIFF
--- a/nbt/region.py
+++ b/nbt/region.py
@@ -365,7 +365,11 @@ class RegionFile(object):
             if ignore_chunk == m:
                 continue
             if m.blocklength and m.blockstart:
-                for b in range(m.blockstart, m.blockstart + max(m.blocklength, m.requiredblocks())):
+                # When a chunk has mismatched length status, the length in bytes attribute can be HUGE
+                # and a call to _sectros can take minutes to finish. Only trust length when the chunk has not
+                # a mismatched length status.
+                num_blocks = m.requiredblocks() if m.status != STATUS_CHUNK_MISMATCHED_LENGTHS else m.blocklength
+                for b in range(m.blockstart, m.blockstart + num_blocks):
                     if 2 <= b < sectorsize:
                         sectors[b].append(m)
         return sectors


### PR DESCRIPTION
Hello!

Just found what I think is a bug. When you try to unlink a chunk that has the status mismatched lengths, and the length attribute of the chunks is ridiculous big, it can take minutes to finish the call because of how the requiereblocks() calculate the block size.

Here is small fix for that problem.

Please, if you don't like the fix, feel free to implement it in any way you like.