### PR TITLE
Fixes for #76 and #78

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
  - "2.7"
  - "3.2"
  - "3.3"
+ - "3.4"
  - "pypy"
+ - "pypy3"
 install: 
  - sudo apt-get install zlib1g zlib1g-dev wget
  - sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
  - "pypy"
  - "pypy3"
 install: 
- - sudo apt-get install zlib1g zlib1g-dev wget
+ - sudo apt-get install zlib1g zlib1g-dev curl
  - sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/
- - pip install pillow unittest2 --use-mirrors ; true
+ - pip install pillow unittest2 ; true
 script: tests/alltests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
  - "3.3"
  - "pypy"
 install: 
- - sudo apt-get install zlib1g zlib1g-dev
+ - sudo apt-get install zlib1g zlib1g-dev wget
  - sudo ln -s /usr/lib/x86_64-linux-gnu/libz.so /usr/lib/
  - pip install pillow unittest2 --use-mirrors ; true
 script: tests/alltests.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,6 +14,8 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext rst
 
+default: wiki
+
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  wiki       to make ReST files for the NBT wiki"

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -18,6 +18,13 @@ manually installed::
 
     pip install unittest2
 
+Due to insecurity of HTTPS in urllib2, it does no longer work for Python up
+to 2.7.9. In that case, the external wget program is used to download a sample
+file. Note that urllib2 before 2.7.9 or 3.4.2 never checked the HTTPS (x509)
+certificates. A SHA256 checksum is calculated to check the validity of the
+downloaded files.
+
+
 ``downloadsample`` script
 -------------------------
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -19,7 +19,7 @@ manually installed::
     pip install unittest2
 
 Due to insecurity of HTTPS in urllib2, it does no longer work for Python up
-to 2.7.9. In that case, the external wget program is used to download a sample
+to 2.7.9. In that case, the external curl program is used to download a sample
 file. Note that urllib2 before 2.7.9 or 3.4.2 never checked the HTTPS (x509)
 certificates. A SHA256 checksum is calculated to check the validity of the
 downloaded files.

--- a/examples/block_analysis.py
+++ b/examples/block_analysis.py
@@ -50,8 +50,8 @@ def bounded_stats_per_chunk(chunk, block_data_totals, start, stop):
 def process_region_file(filename, start, stop):
     """Given a region filename, return the number of blocks of each ID in that file"""
     pieces = filename.split('.')
-    rx = int(pieces[1])
-    rz = int(pieces[2])
+    rx = int(pieces[-3])
+    rz = int(pieces[-2])
     
     block_data_totals = [[0]*16 for i in range(256)] # up to 16 data numbers in 256 block IDs
     

--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -484,6 +484,15 @@ TAGLIST = {TAG_END: _TAG_End, TAG_BYTE:TAG_Byte, TAG_SHORT:TAG_Short, TAG_INT:TA
 class NBTFile(TAG_Compound):
     """Represent an NBT file object."""
     def __init__(self, filename=None, buffer=None, fileobj=None):
+        """
+        Create a new NBTFile object.
+        Specify either a filename, file object or data buffer.
+        If filename of file object is specified, data should be GZip-compressed.
+        If a data buffer is specified, it is assumed to be uncompressed.
+        
+        If filename is specified, the file is closed after reading and writing.
+        If file object is specified, the caller is responsible for closing the file.
+        """
         super(NBTFile, self).__init__()
         self.filename = filename
         self.type = TAG_Byte(self.id)

--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -508,7 +508,7 @@ class NBTFile(TAG_Compound):
             self.parse_file()
             if closefile:
                 # Note: GzipFile().close() does NOT close the fileobj, 
-                # So the caller is still responsible for closing that.
+                # So we are still responsible for closing that.
                 try:
                     self.file.close()
                 except (AttributeError, IOError):

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -263,9 +263,15 @@ class RegionFile(object):
         sectors, remainder = divmod(bsize, sectorlength)
         return sectors if remainder == 0 else sectors + 1
     
-    def __del__(self):
+    def close(self):
         if self._closefile:
-            self.file.close()
+            try:
+                self.file.close()
+            except IOError:
+                pass
+
+    def __del__(self):
+        self.close()
         # Parent object() has no __del__ method, otherwise it should be called here.
 
     def _init_file(self):

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -488,7 +488,7 @@ class RegionFile(object):
         elif m.status == STATUS_CHUNK_IN_HEADER:
             raise RegionHeaderError('Chunk %d,%d is in the region header' % (x,z))
         elif m.status == STATUS_CHUNK_OUT_OF_FILE and (m.length <= 1 or m.compression == None):
-            # Check header is outside of the file.
+            # Chunk header is outside of the file.
             raise RegionHeaderError('Chunk %d,%d is partially/completely outside the file' % (x,z))
         elif m.status == STATUS_CHUNK_ZERO_LENGTH:
             if m.blocklength == 0:

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -365,9 +365,10 @@ class RegionFile(object):
             if ignore_chunk == m:
                 continue
             if m.blocklength and m.blockstart:
-                for b in range(m.blockstart, m.blockstart + max(m.blocklength, m.requiredblocks())):
-                    if 2 <= b < sectorsize:
-                        sectors[b].append(m)
+                blockend = m.blockstart + max(m.blocklength, m.requiredblocks())
+                # Ensure 2 <= b < sectorsize, as well as m.blockstart <= b < blockend
+                for b in range(max(m.blockstart, 2), min(blockend, sectorsize)):
+                    sectors[b].append(m)
         return sectors
 
     def _locate_free_sectors(self, ignore_chunk=None):

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -583,6 +583,13 @@ class RegionFile(object):
         free_sectors = self._locate_free_sectors(ignore_chunk=current)
         sector = self._find_free_location(free_sectors, nsectors, preferred=current.blockstart)
 
+        # If file is smaller than sector*SECTOR_LENGTH (it was truncated), pad it with zeroes.
+        if self.size < sector*SECTOR_LENGTH:
+            # jump to end of file
+            self.file.seek(0, SEEK_END)
+            self.file.write((sector*SECTOR_LENGTH - self.size) * b"\x00")
+            assert self.file.tell() == sector*SECTOR_LENGTH
+
         # write out chunk to region
         self.file.seek(sector*SECTOR_LENGTH)
         self.file.write(pack(">I", length + 1)) #length field

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -118,7 +118,7 @@ class ChunkMetadata(object):
         - STATUS_CHUNK_OK
         - STATUS_CHUNK_NOT_CREATED"""
     def __str__(self):
-        return "%s(%d, %d, sector=%s, length=%s, timestamp=%s, lenght=%s, compression=%s, status=%s)" % \
+        return "%s(%d, %d, sector=%s, blocklength=%s, timestamp=%s, bytelength=%s, compression=%s, status=%s)" % \
             (self.__class__.__name__, self.x, self.z, self.blockstart, self.blocklength, self.timestamp, \
             self.length, self.compression, self.status)
     def __repr__(self):
@@ -183,8 +183,8 @@ class RegionFile(object):
     
     def __init__(self, filename=None, fileobj=None):
         """
-        Read a region file by filename of file object. 
-        If a fileobj is specified, it is not closed after use; it is the callers responibility to close that.
+        Read a region file by filename or file object. 
+        If a fileobj is specified, it is not closed after use; it is the callers responibility to close it.
         """
         self.file = None
         self.filename = None
@@ -302,7 +302,7 @@ class RegionFile(object):
             m = self.metadata[x, z]
             
             self.file.seek(index)
-            offset, length = unpack(">IB", b"\0"+self.file.read(4))
+            offset, length = unpack(">IB", b"\0" + self.file.read(4))
             m.blockstart, m.blocklength = offset, length
             self.file.seek(index + SECTOR_LENGTH)
             m.timestamp = unpack(">I", self.file.read(4))[0]

--- a/tests/alltests.py
+++ b/tests/alltests.py
@@ -53,4 +53,4 @@ if __name__ == "__main__":
         # Logging is not yet configured. Configure it.
         logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(levelname)-8s %(message)s')
     testresult = unittest.TextTestRunner(verbosity=2).run(load_tests_in_modules(testmodules))
-    sys.exit(not testresult.wasSuccessful())
+    sys.exit(0 if testresult.wasSuccessful() else -1)

--- a/tests/alltests.py
+++ b/tests/alltests.py
@@ -53,4 +53,4 @@ if __name__ == "__main__":
         # Logging is not yet configured. Configure it.
         logging.basicConfig(level=logging.INFO, stream=sys.stderr, format='%(levelname)-8s %(message)s')
     testresult = unittest.TextTestRunner(verbosity=2).run(load_tests_in_modules(testmodules))
-    sys.exit(0 if testresult.wasSuccessful() else -1)
+    sys.exit(0 if testresult.wasSuccessful() else 1)

--- a/tests/downloadsample.py
+++ b/tests/downloadsample.py
@@ -79,7 +79,7 @@ def download(url, destination):
             if not data: break
             localfile.write(data)
             size += len(data)
-            print("Downloaded %0.1f MiByte..." % (float(size)/1048576))
+            logging.info("Downloaded %0.1f MiByte..." % (float(size)/1048576))
     finally:
         try:
             localfile.close()

--- a/tests/downloadsample.py
+++ b/tests/downloadsample.py
@@ -154,6 +154,7 @@ def install(url=URL, workdir=workdir, checksums=checksums):
     # - posixpaths: list of relative posix paths -- to filter tar extraction
     # - nchecksums: as checksum, but with normalised absolute paths
     # - files: list of normalised absolute path of files (non-directories)
+    logger = logging.getLogger("nbt.tests.downloadsample")
     posixpaths = checksums.keys()
     nchecksums = dict([(os.path.join(workdir, os.path.normpath(path)), checksums[path]) \
             for path in posixpaths if checksums[path] != None])

--- a/tests/downloadsample.py
+++ b/tests/downloadsample.py
@@ -11,12 +11,14 @@ try:
 except ImportError:
     import urllib2 as urllib   # Python 2
 import logging
+import subprocess
 import tarfile
 import hashlib
 
 import glob
 import tempfile
 import shutil
+
 
 URL = "https://github.com/downloads/twoolie/NBT/Sample_World.tar.gz"
 """URL to retrieve"""
@@ -49,17 +51,27 @@ def download(url, destination):
     """
     Download the file from the specified URL, and extract the contents.
     
-    May raise an IOError (or one of it's subclasses) upon error, either
-    in reading from the URL of writing to file.
+    Uses urllib2.
+    
+    WARNING: urllib2 does not verify the certificate for Python 
+    earlier than 2.7.9 or 3.4.2 (!). Verify the checksums before using 
+    the downloaded files.
+
+    Warning: Before Python 2.7.9, urllib2 can't download over HTTPS, since 
+    it effectively only supports SSLv3, which is nowadays deprecated by websites.
+    In these cases, the following SSLError is raised:
+    error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
+    
+    May raise an IOError or SSLError.
     """
     logger = logging.getLogger("nbt.tests.downloadsample")
     localfile = None
     remotefile = None
     try:
+        logger.info("Downloading %s" % url)
         request = urllib.Request(url)
         remotefile = urllib.urlopen(request)
         localfile = open(destination, 'wb')
-        logger.info("Downloading %s" % url)
         chunksize = 524288 # 0.5 MiB
         size = 0
         while True:
@@ -67,14 +79,30 @@ def download(url, destination):
             if not data: break
             localfile.write(data)
             size += len(data)
-            logging.info("Downloaded %0.1f MiByte..." % (float(size)/1048576))
+            print("Downloaded %0.1f MiByte..." % (float(size)/1048576))
     finally:
         try:
-            remotefile.close()
             localfile.close()
         except (IOError, AttributeError):
             pass
     logging.info("Download complete")
+
+def download_with_wget(url, destination):
+    """
+    Download the file from the specified URL, and extract the contents.
+    
+    Uses the external wget program.
+    
+    May raise an OSError (or one of it's subclasses).
+    """
+    logger = logging.getLogger("nbt.tests.downloadsample")
+    logger.info("Downloading %s (with wget)" % url)
+    command = ['wget', '-O', destination, url]
+    # Open a subprocess, wait till it is done, and get the STDOUT result
+    exitcode = subprocess.call(command)
+    print("exitcode =", exitcode)
+
+
 
 def extract(filename, workdir, filelist):
     """
@@ -85,7 +113,7 @@ def extract(filename, workdir, filelist):
     Extraneous files will be logged as warning.
     """
     logger = logging.getLogger("nbt.tests.downloadsample")
-    logger.info("Extracting")
+    logger.info("Extracting %s" % filename)
     def filefilter(members):
         for tarinfo in members:
             if tarinfo.name in filelist:
@@ -159,26 +187,45 @@ def install(url=URL, workdir=workdir, checksums=checksums):
     nchecksums = dict([(os.path.join(workdir, os.path.normpath(path)), checksums[path]) \
             for path in posixpaths if checksums[path] != None])
     files = nchecksums.keys()
-    tarfile = os.path.join(workdir, os.path.basename(url))
+    tar_file = os.path.join(workdir, os.path.basename(url))
     
-    try:
-        if not any(map(os.path.exists, files)):
-            # none destination file exists. We can safely download/extract without overwriting.
-            if not os.path.exists(tarfile):
-                download(url=URL, destination=tarfile)
-            extract(filename=tarfile, workdir=workdir, filelist=posixpaths)
-        return verify(checksums=nchecksums)
-    except urllib.HTTPError as e:
-        logger.error('Download %s failed: HTTP Error %d: %s\n' % (url, e.code, e.reason))
-    except urllib.URLError as e:
-        # e.reason may be a socket.error. If so, print e.reason.strerror.
-        logger.error('Download %s failed: %s\n' % \
-                (url, e.reason.strerror if hasattr(e.reason, "strerror") else e.reason))
-    except tarfile.TarError as e:
-        logger.error('Extract %s failed: %s\n' % (tarfile, e.message))
-    except IOError as e:
-        logger.error('Download to %s failed: %s' % (e.filename, e.strerror))
-    return False
+    if not any(map(os.path.exists, files)):
+    # none of the destination files exist. We can safely download/extract without overwriting.
+        if not os.path.exists(tar_file):
+            has_ssl_error = False
+            try:
+                download(url=URL, destination=tar_file)
+            except urllib.URLError as e:
+                # e.reason may be a socket.error. If so, print e.reason.strerror.
+                logger.error('Download %s failed: %s %s' % (url,type(e),e))
+                logger.error('Download %s failed: %s' % \
+                        (url, e.reason.strerror if hasattr(e.reason, "strerror") else e.reason))
+                has_ssl_error = "sslv3" in ("%s" % e)
+            except urllib.HTTPError as e:
+                # urllib.HTTPError.reason does not have a reason in Python 2.6 (perhaps neither in 2.7).
+                logger.error('Download %s failed: %s %s' % (url,type(e),e))
+                logger.error('Download %s failed: HTTP Error %d: %s' % (url, e.code, \
+                        e.reason if hasattr(e, "reason") else e))
+                return False
+            except Exception as e:
+                logger.error('Download %s failed: %s %s' % (url,type(e),e))
+                # logger.error('Download %s failed: %s' % (url, e))
+                return False
+            if has_ssl_error:
+                try:
+                    download_with_wget(url=URL, destination=tar_file)
+                except Exception as e:
+                    logger.error('Download %s failed: %s' % (url, e))
+                    return False
+        try:
+            extract(filename=tar_file, workdir=workdir, filelist=posixpaths)
+        except tarfile.TarError as e:
+            logger.error('Extract %s failed: %s' % (tar_file, e.message))
+            return False
+        except Exception as e:
+            logger.error('Extract %s failed: %s' % (tar_file, e))
+            return False
+    return verify(checksums=nchecksums)
 
 
 

--- a/tests/examplestests.py
+++ b/tests/examplestests.py
@@ -59,7 +59,10 @@ class ScriptTestCase(unittest.TestCase):
         # Ensure we're using the same python version.
         # python = sys.argv[0]
         # args.insert(0, python)
-        p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        env = dict(os.environ).copy()
+        env['LC_ALL'] = 'C'
+        # Open a subprocess, wait till it is done, and get the STDOUT result
+        p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         p.wait()
         output = [r.decode('utf-8') for r in p.stdout.readlines()]
         for l in p.stderr.readlines():

--- a/tests/regiontests.py
+++ b/tests/regiontests.py
@@ -1284,12 +1284,17 @@ class LengthTest(unittest.TestCase):
                      RegionFile.STATUS_CHUNK_OUT_OF_FILE))
     
     def testChunkRead(self):
-        # performa low-level read, ensure it does not read past the file length
-        # and does not modify the file
-        data = self.region.get_blockdata(0, 0) # May raise a ChunkHeaderError() or ChunkDataError()
+        """
+        Perform a low-level read, ensure it does not read past the file length
+        and does not modify the file.
+        """
+        # Does not raise a ChunkDataError(), since the data can be read, 
+        # even though it is shorter than specified in the header.
+        data = self.region.get_blockdata(0, 0)
         self.assertEqual(len(data), 8187)
-        data = self.region.get_blockdata(1, 0) # May raise a ChunkHeaderError() or ChunkDataError()
+        data = self.region.get_blockdata(1, 0)
         self.assertEqual(len(data), 4091)
+        self.assertEqual(self.region.get_size(), self.length)
     
     def testDeleteChunk(self):
         """Try to remove the chunk 1,0 with ridiculous large size. 

--- a/tests/regiontests.py
+++ b/tests/regiontests.py
@@ -85,8 +85,8 @@ def generate_compressed_level(minsize = 2000, maxsize = None):
         bytesize = int(round(bytesize * targetsize / resultsize))
         tries += 1
         if tries > 20:
-            sys.stderr.write("Failed to generate NBT file of %d bytes after %d tries. " + \
-                             "Result is %d bytes.\n" % (targetsize, tries, resultsize))
+            sys.stderr.write(("Failed to generate NBT file of %d bytes after %d tries. " + \
+                             "Result is %d bytes.\n") % (targetsize, tries, resultsize))
             break
     return level
 

--- a/tests/regiontests.py
+++ b/tests/regiontests.py
@@ -1097,7 +1097,7 @@ class RegionFileInitTest(unittest.TestCase):
         tempdir = tempfile.mkdtemp()
         filename = os.path.join(tempdir, 'regiontest.mca')
         shutil.copy(REGIONTESTFILE, filename)
-        fileobj = open(filename, "br")
+        fileobj = open(filename, "r+b")
         
         try:
             openfiles_before = open_files()
@@ -1126,7 +1126,7 @@ class RegionFileInitTest(unittest.TestCase):
         shutil.copy(REGIONTESTFILE, filename_name)
         filename_obj = os.path.join(tempdir, 'regiontest_obj.mca')
         shutil.copy(REGIONTESTFILE, filename_obj)
-        fileobj = open(filename_obj, "br")
+        fileobj = open(filename_obj, "r+b")
         
         try:
             openfiles_before = open_files()

--- a/tests/regiontests.py
+++ b/tests/regiontests.py
@@ -76,14 +76,16 @@ def generate_compressed_level(minsize = 2000, maxsize = None):
         c = zlib.compress(b, 1)
         # check if the compressed size is sufficient.
         resultsize = len(c)
-        logger.debug("try %d: uncompressed %d bytes -> compressed %d bytes" % (tries, bytesize, resultsize))
+        logger.debug("try %d: uncompressed %d bytes -> compressed %d bytes" % \
+                     (tries, bytesize, resultsize))
         if minsize <= resultsize <= maxsize:
             break
         # size is not good enough. Try again, with new targetsize.
         bytesize = int(round(bytesize * targetsize / resultsize))
         tries += 1
         if tries > 20:
-            sys.stderr.write("Failed to generate NBT file of %d bytes after %d tries. Result is %d bytes.\n" % (targetsize, tries, resultsize))
+            sys.stderr.write("Failed to generate NBT file of %d bytes after %d tries. " + \
+                             "Result is %d bytes.\n" % (targetsize, tries, resultsize))
             break
     return level
 
@@ -326,7 +328,8 @@ class ReadWriteTest(unittest.TestCase):
         read headers & chunk_headers of chunk 2,2
         """
         self.assertEqual(self.region.header[2,2], (0, 0, 0, RegionFile.STATUS_CHUNK_NOT_CREATED))
-        self.assertEqual(self.region.chunk_headers[2,2], (None, None, RegionFile.STATUS_CHUNK_NOT_CREATED))
+        self.assertEqual(self.region.chunk_headers[2,2], \
+                        (None, None, RegionFile.STATUS_CHUNK_NOT_CREATED))
     
     def test010ReadChunkZlibCompression(self):
         """
@@ -368,7 +371,8 @@ class ReadWriteTest(unittest.TestCase):
     # TODO: raise nbt.region.ChunkDataError instead of nbt.nbt.MalformedFileError, or make them the same.
     def test015ReadMalformedNBT(self):
         """
-        read chunk 5,1: valid compression, but not a valid NBT file. Reading should raise a ChunkDataError.
+        read chunk 5,1: valid compression, but not a valid NBT file. 
+        Reading should raise a ChunkDataError.
         """
         self.assertRaises(ChunkDataError, self.region.get_nbt, 5, 1)
 
@@ -421,24 +425,30 @@ class ReadWriteTest(unittest.TestCase):
         """
         self.assertRaises(RegionHeaderError, self.region.get_nbt, 14, 0)
         # TODO:
-        self.assertEqual(self.region.header[14,0], (1, 1, 1376433960, RegionFile.STATUS_CHUNK_IN_HEADER))
-        self.assertEqual(self.region.chunk_headers[14,0], (None, None, RegionFile.STATUS_CHUNK_IN_HEADER))
+        self.assertEqual(self.region.header[14,0], 
+                         (1, 1, 1376433960, RegionFile.STATUS_CHUNK_IN_HEADER))
+        self.assertEqual(self.region.chunk_headers[14,0], 
+                         (None, None, RegionFile.STATUS_CHUNK_IN_HEADER))
 
     def test021ReadOutOfFile(self):
         """
         read chunk 15,0: error (out of file)
         """
         self.assertRaises(RegionHeaderError, self.region.get_nbt, 15, 0)
-        self.assertEqual(self.region.header[15,0], (30, 1, 1376433961, RegionFile.STATUS_CHUNK_OUT_OF_FILE))
-        self.assertEqual(self.region.chunk_headers[15,0], (None, None, RegionFile.STATUS_CHUNK_OUT_OF_FILE))
+        self.assertEqual(self.region.header[15,0], 
+                         (30, 1, 1376433961, RegionFile.STATUS_CHUNK_OUT_OF_FILE))
+        self.assertEqual(self.region.chunk_headers[15,0], 
+                         (None, None, RegionFile.STATUS_CHUNK_OUT_OF_FILE))
 
     def test022ReadZeroLengthHeader(self):
         """
         read chunk 13,0: error (zero-length)
         """
         self.assertRaises(RegionHeaderError, self.region.get_nbt, 13, 0)
-        self.assertEqual(self.region.header[13,0], (21, 0, 1376433958, RegionFile.STATUS_CHUNK_ZERO_LENGTH))
-        self.assertEqual(self.region.chunk_headers[13,0], (None, None, RegionFile.STATUS_CHUNK_ZERO_LENGTH))
+        self.assertEqual(self.region.header[13,0], 
+                         (21, 0, 1376433958, RegionFile.STATUS_CHUNK_ZERO_LENGTH))
+        self.assertEqual(self.region.chunk_headers[13,0],
+                         (None, None, RegionFile.STATUS_CHUNK_ZERO_LENGTH))
 
     def test023ReadInvalidLengthChunk(self):
         """
@@ -455,11 +465,13 @@ class ReadWriteTest(unittest.TestCase):
 
     def test025ReadChunkSizeExceedsSectorSize(self):
         """
-        read chunk 3,1: can be read, despite that the chunk content is longer than the allocated sectors.
+        read chunk 3,1: can be read, despite that the chunk content is longer 
+        than the allocated sectors.
         In general, reading should either succeeds, or raises a ChunkDataError.
         The status should be STATUS_CHUNK_MISMATCHED_LENGTHS.
         """
-        self.assertEqual(self.region.chunk_headers[3,1][2], RegionFile.STATUS_CHUNK_MISMATCHED_LENGTHS)
+        self.assertEqual(self.region.chunk_headers[3,1][2], 
+                         RegionFile.STATUS_CHUNK_MISMATCHED_LENGTHS)
         # reading should succeed, despite the overlap (next chunk is free)
         nbt = self.region.get_nbt(3, 1)
 
@@ -467,8 +479,10 @@ class ReadWriteTest(unittest.TestCase):
         """
         chunk 4,0 and chunk 12,0 overlap: status should be STATUS_CHUNK_OVERLAPPING
         """
-        self.assertEqual(self.region.chunk_headers[4,0][2], RegionFile.STATUS_CHUNK_OVERLAPPING)
-        self.assertEqual(self.region.chunk_headers[12,0][2], RegionFile.STATUS_CHUNK_OVERLAPPING)
+        self.assertEqual(self.region.chunk_headers[4,0][2], 
+                         RegionFile.STATUS_CHUNK_OVERLAPPING)
+        self.assertEqual(self.region.chunk_headers[12,0][2], 
+                         RegionFile.STATUS_CHUNK_OVERLAPPING)
 
     def test030GetTimestampOK(self):
         """
@@ -635,7 +649,8 @@ class ReadWriteTest(unittest.TestCase):
         header = self.region.header[1, 2]
         self.assertEqual(header[1], 3, "Chunk length must be 3 sectors")
         self.assertIn(header[0], (26, 27), "Chunk should be placed in sector 26")
-        self.assertEqual(self.region.get_size(), (header[0] + header[1])*4096, "File size should be multiple of 4096")
+        self.assertEqual(self.region.get_size(), (header[0] + header[1])*4096, \
+                         "File size should be multiple of 4096")
         self.assertEqual(header[3], RegionFile.STATUS_CHUNK_OK)
 
     def test054WriteExistingChunkDecreaseSector(self):
@@ -752,7 +767,8 @@ class ReadWriteTest(unittest.TestCase):
         self.region.write_chunk(13, 0, nbt)
         header = self.region.header[13, 0]
         self.assertEqual(header[1], 1) # length
-        self.assertLessEqual(header[0], 26, "Previously out-of-file chunk should be written in-file")
+        self.assertLessEqual(header[0], 26, \
+                "Previously out-of-file chunk should be written in-file")
 
     def test071WriteZeroLengthSectorChunk(self):
         """
@@ -763,7 +779,8 @@ class ReadWriteTest(unittest.TestCase):
         self.region.write_chunk(13, 0, nbt)
         header = self.region.header[13, 0]
         self.assertEqual(header[1], 1) # length
-        self.assertNotEqual(header[0], 19, "Previously 0-length chunk should not overwrite existing chunk")
+        self.assertNotEqual(header[0], 19, \
+                "Previously 0-length chunk should not overwrite existing chunk")
 
     def test072WriteOverlappingChunkLong(self):
         """
@@ -780,8 +797,10 @@ class ReadWriteTest(unittest.TestCase):
         self.region.write_chunk(4, 0, nbt)
         header = self.region.header[4, 0]
         self.assertEqual(header[1], 2) # length
-        self.assertNotEqual(header[0], 14, "Chunk should not be written to same location when it overlaps")
-        self.assertEqual(header[0], 10, "Chunk should not be written to same location when it overlaps")
+        self.assertNotEqual(header[0], 14, \
+                "Chunk should not be written to same location when it overlaps")
+        self.assertEqual(header[0], 10, \
+                "Chunk should not be written to same location when it overlaps")
         # Write 1-sector chunks to check which sectors are "free"
         nbt = generate_compressed_level(minsize = 100, maxsize = 4000)
         locations = []
@@ -810,7 +829,8 @@ class ReadWriteTest(unittest.TestCase):
         self.region.write_chunk(12, 0, nbt)
         header = self.region.header[12, 0]
         self.assertEqual(header[1], 1) # length
-        self.assertNotEqual(header[0], 15, "Chunk should not be written to same location when it overlaps")
+        self.assertNotEqual(header[0], 15, \
+                "Chunk should not be written to same location when it overlaps")
         # Write 1-sector chunks to check which sectors are "free"
         locations = []
         self.region.write_chunk(1, 2, nbt)
@@ -834,12 +854,14 @@ class ReadWriteTest(unittest.TestCase):
         self.region.write_chunk(12, 0, nbt)
         header = self.region.header[12, 0]
         self.assertEqual(header[1], 1) # length
-        self.assertNotEqual(header[0], 15, "Chunk should not be written to same location when it overlaps")
+        self.assertNotEqual(header[0], 15, \
+                "Chunk should not be written to same location when it overlaps")
         nbt = generate_compressed_level(minsize = 9000, maxsize = 11000)
         self.region.write_chunk(4, 0, nbt)
         header = self.region.header[4, 0]
         self.assertEqual(header[1], 3) # length
-        self.assertEqual(header[0], 14, "No longer overlapping chunks should be written to same location when when possible")
+        self.assertEqual(header[0], 14, "No longer overlapping chunks " + \
+                "should be written to same location when when possible")
 
     def test080FileTruncateLastChunkDecrease(self):
         """
@@ -848,7 +870,8 @@ class ReadWriteTest(unittest.TestCase):
         """
         nbt = generate_compressed_level(minsize = 100, maxsize = 4000)
         self.region.write_chunk(3, 1, nbt)
-        self.assertEqual(self.region.get_size(), 26*4096, "File should be truncated when last chunk is reduced in size")
+        self.assertEqual(self.region.get_size(), 26*4096, \
+                "File should be truncated when last chunk is reduced in size")
 
     def test081FileTruncateFreeTail(self):
         """
@@ -856,7 +879,8 @@ class ReadWriteTest(unittest.TestCase):
         verify file size: 25*4096 bytes
         """
         self.region.unlink_chunk(3, 1)
-        self.assertEqual(self.region.get_size(), 25*4096, "File should be truncated when last sector(s) are freed")
+        self.assertEqual(self.region.get_size(), 25*4096, \
+                "File should be truncated when last sector(s) are freed")
 
     def test082FileTruncateMergeFree(self):
         """
@@ -866,7 +890,8 @@ class ReadWriteTest(unittest.TestCase):
         """
         self.region.unlink_chunk(8, 1)
         self.region.unlink_chunk(3, 1)
-        self.assertEqual(self.region.get_size(), 24*4096, "File should be truncated as far as possible when last sector(s) are freed")
+        self.assertEqual(self.region.get_size(), 24*4096, "File should be " + \
+                "truncated as far as possible when last sector(s) are freed")
 
     def test090DeleteNonExistingChunk(self):
         """
@@ -924,7 +949,8 @@ class ReadWriteTest(unittest.TestCase):
         self.region.file.seek(4096*sectorlocation + chunklength)
         unused = self.region.file.read(unusedlength)
         zeroes = unused.count(b'\x00')
-        self.assertEqual(zeroes, unusedlength, "All unused bytes should be zeroed after writing a chunk")
+        self.assertEqual(zeroes, unusedlength, \
+                "All unused bytes should be zeroed after writing a chunk")
     
     def test101DeleteZeroPadding(self):
         """
@@ -950,19 +976,23 @@ class ReadWriteTest(unittest.TestCase):
         self.region.file.seek((sectorlocation + 1) * 4096)
         unused = self.region.file.read(4096)
         zeroes = unused.count(b'\x00')
-        self.assertNotEqual(zeroes, 4096, "Bytes should not be zeroed after deleting an overlapping chunk")
+        self.assertNotEqual(zeroes, 4096, \
+                "Bytes should not be zeroed after deleting an overlapping chunk")
         self.region.file.seek((sectorlocation) * 4096)
         unused = self.region.file.read(4096)
         zeroes = unused.count(b'\x00')
-        self.assertEqual(zeroes, 4096, "Bytes should be zeroed after deleting non-overlapping portions of a chunk")
+        self.assertEqual(zeroes, 4096, "Bytes should be " + \
+                "zeroed after deleting non-overlapping portions of a chunk")
         self.region.file.seek((sectorlocation + 2) * 4096)
         unused = self.region.file.read(4096)
         zeroes = unused.count(b'\x00')
-        self.assertEqual(zeroes, 4096, "Bytes should be zeroed after deleting non-overlapping portions of a chunk")
+        self.assertEqual(zeroes, 4096, "Bytes should be " + \
+                "zeroed after deleting non-overlapping portions of a chunk")
     
     def test103MoveOverlappingNoZeroPadding(self):
         """
-        write 2 sector chunk 4,0 to a different location. Due to overlapping chunks, bytes should not be zeroed.
+        write 2 sector chunk 4,0 to a different location. 
+        Due to overlapping chunks, bytes should not be zeroed.
         Check if bytes in sector 015 are not all zeroed.
         """
         header = self.region.header[4, 0]
@@ -972,7 +1002,8 @@ class ReadWriteTest(unittest.TestCase):
         self.region.file.seek((sectorlocation + 1) * 4096)
         unused = self.region.file.read(4096)
         zeroes = unused.count(b'\x00')
-        self.assertNotEqual(zeroes, 4096, "Bytes should not be zeroed after moving an overlapping chunk")
+        self.assertNotEqual(zeroes, 4096, \
+                "Bytes should not be zeroed after moving an overlapping chunk")
     
     def test104DeleteZeroPaddingMismatchLength(self):
         """
@@ -1127,13 +1158,20 @@ class RegionFileInitTest(unittest.TestCase):
 
 class TruncatedFileTest(unittest.TestCase):
     """Test for truncated file support.
-    These files should be treated as a valid region file without any stored chunk."""
+    This files should be treated as a valid region file, as all data is present.
+    Only the padding bytes are missing."""
 
     def setUp(self):
+        # data contains 8235, just over 2 sectors.
+        # Only chunk (0,0) is stored, at sector 2, with length 1.
+        # The timestamps are all zeroed.
+        # The chunk is 0x27 = 39 bytes, excl header. Compression type 2, zlib.
         data = b'\x00\x00\x02\x01' + 8188*b'\x00' + \
-               b'\x00\x00\x00\x27\x02\x78\xda\xe3\x62\x60\x71\x49\x2c\x49\x64\x61\x60\x09\xc9\xcc\x4d' + \
-               b'\x65\x80\x00\x46\x0e\x06\x16\xbf\x44\x20\x97\x25\x24\xb5\xb8\x84\x01\x00\x6b\xb7\x06\x52'
-        self.length = 8235
+               b'\x00\x00\x00\x27\x02' + \
+               b'\x78\xda\xe3\x62\x60\x71\x49\x2c\x49\x64\x61\x60\x09\xc9' + \
+               b'\xcc\x4d\x65\x80\x00\x46\x0e\x06\x16\xbf\x44\x20\x97\x25' + \
+               b'\x24\xb5\xb8\x84\x01\x00\x6b\xb7\x06\x52'
+        self.length = 8235 # 4096 + 4096 + 4 + 39
         self.assertEqual(len(data), self.length)
         stream = PedanticFileWrapper(BytesIO(data))
         # stream.seek(0)
@@ -1147,7 +1185,8 @@ class TruncatedFileTest(unittest.TestCase):
         self.assertEqual(self.region.chunk_count(), 1)
     
     def test01ReadChunk(self):
-        """Test if a block can be read, even when the file is truncated right after the block data."""
+        """Test if a block can be read, even when the file is truncated right 
+        after the block data."""
         data = self.region.get_blockdata(0,0) # This may raise a RegionFileFormatError.
         data = BytesIO(data)
         nbt = NBTFile(buffer=data)
@@ -1155,7 +1194,8 @@ class TruncatedFileTest(unittest.TestCase):
         self.assertEqual(nbt["Name"].value, "Test")
 
     def test02ReplaceChunk(self):
-        """Test if writing the last block in a truncated file will extend the file size to the sector boundary."""
+        """Test if writing the last block in a truncated file will extend the 
+        file size to the sector boundary."""
         nbt = self.region.get_nbt(0, 0)
         self.region.write_chunk(0, 0, nbt)
         size = self.region.size
@@ -1236,9 +1276,11 @@ class LengthTest(unittest.TestCase):
         chunk00metadata = self.region.metadata[0,0]
         chunk10metadata = self.region.metadata[1,0]
         self.assertIn(chunk00metadata.status, 
-                    (RegionFile.STATUS_CHUNK_OVERLAPPING, RegionFile.STATUS_CHUNK_OUT_OF_FILE))
+                    (RegionFile.STATUS_CHUNK_OVERLAPPING, 
+                     RegionFile.STATUS_CHUNK_OUT_OF_FILE))
         self.assertIn(chunk10metadata.status, 
-                    (RegionFile.STATUS_CHUNK_MISMATCHED_LENGTHS, RegionFile.STATUS_CHUNK_OVERLAPPING, 
+                    (RegionFile.STATUS_CHUNK_MISMATCHED_LENGTHS, 
+                     RegionFile.STATUS_CHUNK_OVERLAPPING, 
                      RegionFile.STATUS_CHUNK_OUT_OF_FILE))
     
     def testChunkRead(self):


### PR DESCRIPTION
Miscellaneous small improvements
- read/write is never outside of file boundaries. With lots of unit tests (fixes #76)
- Review and improve comments (line wrap, fix typos)
- Make Travis happy again (frustrating details in #78)
- Fix example/block_analysis: support for file paths with dots.
- Change output of str(region.ChunkMetadata()) to distinguish between blocksize and bytesize.