### PR TITLE
Fix link to NBT.txt in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ From The spec:
    amounts of binary data with smaller amounts of additional data.
    An NBT file consists of a single GZIPped Named Tag of type TAG_Compound."
 
-read the full spec at http://www.minecraft.net/docs/NBT.txt
+read the full spec at http://wiki.vg/NBT.txt
 
 [![Build Status](https://secure.travis-ci.org/twoolie/NBT.png?branch=master)](http://travis-ci.org/#!/twoolie/NBT)
 


### PR DESCRIPTION
The original NBT.txt has been taken offline for years now. [wiki.vg](http://wiki.vg/) seems to be the most popular, up-to-date site for technical Minecraft documentation.
