### PR TITLE
Fix & add web links in README and sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-This is a Named Binary Tag parser based upon the specification by Markus Persson.
+This is a "Named Binary Tag" parser & writer, suited for inspecting & editing
+the Minecraft data files.
 
-From The spec:
-  "NBT (Named Binary Tag) is a tag based binary format designed to carry large
-   amounts of binary data with smaller amounts of additional data.
-   An NBT file consists of a single GZIPped Named Tag of type TAG_Compound."
+From the initial specification by Markus Persson:
+```
+NBT (Named Binary Tag) is a tag based binary format designed to carry large
+amounts of binary data with smaller amounts of additional data.
+An NBT file consists of a single GZIPped Named Tag of type TAG_Compound.
+```
 
-read the full spec at http://www.minecraft.net/docs/NBT.txt
+Read the current specification on the official [Minecraft Wiki](https://minecraft.gamepedia.com/NBT_format).
 
 [![Build Status](https://secure.travis-ci.org/twoolie/NBT.png?branch=master)](http://travis-ci.org/#!/twoolie/NBT)
 [![Test Coverage Status](https://coveralls.io/repos/twoolie/NBT/badge.svg)](https://coveralls.io/r/twoolie/NBT)

--- a/README.txt
+++ b/README.txt
@@ -1,11 +1,12 @@
-This is a Named Binary Tag parser based upon the specification by Markus Persson.
+This is a "Named Binary Tag" parser & writer, suited for inspecting & editing
+the Minecraft data files.
 
-From The spec:
+From the initial specification by Markus Persson:
   "NBT (Named Binary Tag) is a tag based binary format designed to carry large
    amounts of binary data with smaller amounts of additional data.
    An NBT file consists of a single GZIPped Named Tag of type TAG_Compound."
 
-read the full spec at http://www.minecraft.net/docs/NBT.txt
+Read the current specification at https://minecraft.gamepedia.com/NBT_format.
 
 Usage:
  1) Reading files.

--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -8,7 +8,11 @@ and do the appropriate lookups and block conversions yourself.
 The authors decided to focus on NBT datastructure and Region files, 
 and are not actively working on chunk.py.
 Code contributions to chunk.py are welcomed!
+
+For more information about the chunck format:
+https://minecraft.gamepedia.com/Chunk_format
 """
+
 from io import BytesIO
 from struct import pack, unpack
 import array, math

--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -1,5 +1,8 @@
 """
 Handle the NBT (Named Binary Tag) data format
+
+For more information about the NBT format:
+https://minecraft.gamepedia.com/NBT_format
 """
 
 from struct import Struct, error as StructError

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -1,7 +1,8 @@
 """
 Handle a region file, containing 32x32 chunks.
-For more info of the region file format look:
-http://www.minecraftwiki.net/wiki/Region_file_format
+
+For more information about the region file format:
+https://minecraft.gamepedia.com/Region_file_format
 """
 
 from .nbt import NBTFile, MalformedFileError

--- a/nbt/world.py
+++ b/nbt/world.py
@@ -1,5 +1,8 @@
 """
 Handles a Minecraft world save using either the Anvil or McRegion format.
+
+For more information about the world format:
+https://minecraft.gamepedia.com/Level_format
 """
 
 import os, glob, re


### PR DESCRIPTION
Issue #99 reported a broken link in the README. Fixed it and one other in `region.py`. Also added more links to the official Minecraft Wiki in `nbt.py`, `chunck.py` and `world.py`.