### PR TITLE
Support Python 3.7 in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 # Configuration file for travis-ci.org. Travis is a /continuous integration/ tool that runs tests.
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  # not supported yet by Travis
-  #- "3.7"
-  - "pypy"
-  - "pypy3"
+matrix:
+  include:
+  - python: "2.7"
+  - python: "3.4"
+  - python: "3.5"
+  - python: "3.6"
+  - python: "3.7"
+    # Python 3.7 requires Ubuntu Xenial
+    dist: xenial
+  - python: "pypy3.5"
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
- Added Python 3.7 tests in Travis. This requires Travis to load the Ubuntu Xenial distribution, rather than an older Ubuntu distribution (Trusty or Precise).
- Also re-added Python 3.4. Python 3.4 is outdated, but the code works, and it is good to know which commit will break that. Python 3.4 is still the default for Debian jessie (oldstable), and there are some distribs based on that. Admittedly not likely in this (gaming) community, though.
- removed pypy + pypy3 in favour of pypy3.5. Somehow it failed, and the Travis documentation suggested to specify the exact version.