### PR TITLE
Update chunk.py

### DIFF
--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -217,7 +217,7 @@ class AnvilSection(object):
 
                 lh = (lh & (pow(2, bh) - 1)) << bl
                 ll = (ll & (pow(2, bl) - 1))
-                self.indexes.append(lh & ll)
+                self.indexes.append(lh | ll)
 
                 ll = states[j]
                 ll = ll >> bh


### PR DESCRIPTION
I am not sure but it seems that the bitwise and should be a bitwise or.
At least this fixes some problems I am encountering when plotting maps.

In particular, when the palette requires 5 bits entries, I am getting an artifact each 13 blocks. So each time the entry is written on two different longs of the state array.

Look at those chunk slices:
after the fix
![image](https://user-images.githubusercontent.com/48536116/54385748-a6906e00-4697-11e9-9890-aaef4aa4cab1.png)
before the fix
![image](https://user-images.githubusercontent.com/48536116/54385835-dccded80-4697-11e9-8944-42041f1df2b6.png)

