### PR TITLE
If buffer is provided, don't close file.

### DIFF
--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -640,12 +640,14 @@ class NBTFile(TAG_Compound):
 
     def parse_file(self, filename=None, buffer=None, fileobj=None):
         """Completely parse a file, extracting all tags."""
+        closefile = True
         if filename:
             self.file = GzipFile(filename, 'rb')
         elif buffer:
             if hasattr(buffer, 'name'):
                 self.filename = buffer.name
             self.file = buffer
+            closefile = False
         elif fileobj:
             if hasattr(fileobj, 'name'):
                 self.filename = fileobj.name
@@ -657,7 +659,8 @@ class NBTFile(TAG_Compound):
                     name = TAG_String(buffer=self.file).value
                     self._parse_buffer(self.file)
                     self.name = name
-                    self.file.close()
+                    if closefile:
+                        self.file.close()
                 else:
                     raise MalformedFileError(
                         "First record is not a Compound Tag")


### PR DESCRIPTION
When parsing a buffer, the NBTFile class attempts to `close` the buffer once complete.. which isn't possible. This pull request fixes this issue and stops cases of `AttributeError: 'EpicBytesIOClassNameHere' object has no attribute 'close'`