### PR TITLE
🐎 TAG_Compound uses OrderedDict for speed

### DIFF
--- a/examples/generate_level_dat.py
+++ b/examples/generate_level_dat.py
@@ -22,29 +22,27 @@ from nbt.nbt import NBTFile, TAG_Long, TAG_Int, TAG_String, TAG_Compound
 def generate_level():
     level = NBTFile() # Blank NBT
     level.name = "Data"
-    level.tags.extend([
-        TAG_Long(name="Time", value=1),
-        TAG_Long(name="LastPlayed", value=int(time.time())),
-        TAG_Int(name="SpawnX", value=0),
-        TAG_Int(name="SpawnY", value=2),
-        TAG_Int(name="SpawnZ", value=0),
-        TAG_Long(name="SizeOnDisk", value=0),
-        TAG_Long(name="RandomSeed", value=random.randrange(1,9999999999)),
-        TAG_Int(name="version", value=19132),
-        TAG_String(name="LevelName", value="Testing")
-    ])
-    
+    level["Time"] = TAG_Long(name="Time", value=1)
+    level["LastPlayed"] = TAG_Long(name="LastPlayed", value=int(time.time()))
+    level["SpawnX"] = TAG_Int(name="SpawnX", value=0)
+    level["SpawnY"] = TAG_Int(name="SpawnY", value=2)
+    level["SpawnZ"] = TAG_Int(name="SpawnZ", value=0)
+    level["SizeOnDisk"] = TAG_Long(name="SizeOnDisk", value=0)
+    level["RandomSeed"] = TAG_Long(name="RandomSeed", value=random.randrange(1,9999999999))
+    level["version"] = TAG_Int(name="version", value=19132)
+    level["LevelName"] = TAG_String(name="LevelName", value="Testing")
+
     player = TAG_Compound()
     player.name = "Player"
-    player.tags.extend([
-        TAG_Int(name="Score", value=0),
-        TAG_Int(name="Dimension", value=0)
-    ])
+    player['Score'] = TAG_Int(name="Score", value=0)
+    player['Dimension'] = TAG_Int(name="Dimension", value=0)
+
     inventory = TAG_Compound()
     inventory.name = "Inventory"
-    player.tags.append(inventory)
-    level.tags.append(player)
-    
+
+    player["Inventory"] = inventory
+    level["Player"] = player
+
     return level
 
 

--- a/tests/nbttests.py
+++ b/tests/nbttests.py
@@ -72,7 +72,7 @@ class ReadWriteTest(unittest.TestCase):
         """
         #open the file
         mynbt = NBTFile(self.filename)
-        mynbt['test'] = TAG_Int(123)
+        mynbt['test'] = TAG_Int(name='test', value=123)
         mynbt.write_file()
         if hasattr(mynbt.file, "closed"):
             self.assertTrue(mynbt.file.closed)

--- a/tests/regiontests.py
+++ b/tests/regiontests.py
@@ -41,7 +41,8 @@ def generate_level(bytesize = 4):
         # level.append(byte_array)
         byte_array = TAG_Byte_Array(name=name)
         byte_array.value = bytearray([random.randrange(256) for i in range(bytesize)])
-        level.tags.append(byte_array)
+        level[name] = byte_array
+
     random.seed(123456789) # fixed seed to give predictable results.
     if bytesize < 13:
         raise ValueError("NBT file size is at least 13 bytes")
@@ -989,27 +990,27 @@ class EmptyFileTest(unittest.TestCase):
     def generate_level():
         level = NBTFile() # Blank NBT
         level.name = "Data"
-        level.tags.extend([
-            TAG_Long(name="Time", value=1),
-            TAG_Long(name="LastPlayed", value=1376031942),
-            TAG_Int(name="SpawnX", value=0),
-            TAG_Int(name="SpawnY", value=2),
-            TAG_Int(name="SpawnZ", value=0),
-            TAG_Long(name="SizeOnDisk", value=0),
-            TAG_Long(name="RandomSeed", value=123456789),
-            TAG_Int(name="version", value=19132),
-            TAG_String(name="LevelName", value="Testing")
-        ])
+        level['Time'] = TAG_Long(name="Time", value=1)
+        level['LastPlayed'] = TAG_Long(name="LastPlayed", value=1376031942)
+        level['SpawnX'] = TAG_Int(name="SpawnX", value=0)
+        level['SpawnY'] = TAG_Int(name="SpawnY", value=2)
+        level['SpawnZ'] = TAG_Int(name="SpawnZ", value=0)
+        level['SizeOnDisk'] = TAG_Long(name="SizeOnDisk", value=0)
+        level['RandomSeed'] = TAG_Long(name="RandomSeed", value=123456789)
+        level['version'] = TAG_Int(name="version", value=19132)
+        level['LevelName'] = TAG_String(name="LevelName", value="Testing")
+
         player = TAG_Compound()
         player.name = "Player"
-        player.tags.extend([
-            TAG_Int(name="Score", value=0),
-            TAG_Int(name="Dimension", value=0)
-        ])
+        player['Score'] = TAG_Int(name="Score", value=0)
+        player['Dimension'] = TAG_Int(name="Dimension", value=0)
+
         inventory = TAG_Compound()
         inventory.name = "Inventory"
-        player.tags.append(inventory)
-        level.tags.append(player)
+
+        player['Inventory'] = inventory
+        level['Inventory'] = inventory
+
         return level
 
     def setUp(self):


### PR DESCRIPTION
The TAG_Compound now uses an OrderedDict internally for its mapping
between tag names and tags, to allow for much faster lookup by tag name.
Looking up tags by index number functions as before.

The .tags list has been changed into a read-only property (now a tuple).
The method for adding new tags to a TAG_Compound is by direct item
assignment.

A number of tests used the internal .tags list of TAG_Compound, they
have been changed to use item assignment.

---

This is very much a change in API, I don't know what other projects use this library, assuming that .tags is a mutable list. Certainly some (but not many) of the tests that make arbitrary compounds used that.

I'm building a project that is using the [anvil library](https://github.com/matcool/anvil-parser), and making these changes to NBT cut the run times in half.

So it might be useful to those upstream?