### PR TITLE
added name of tag getter, for viewing pallet block names

### DIFF
--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -64,6 +64,10 @@ class TAG(object):
         returns a summary."""
         return unicode(self.value)
 
+    def namestr(self):
+        """Return Unicode string of tag name."""
+        return unicode(self.name)
+
     def pretty_tree(self, indent=0):
         """Return formated Unicode string of self, where iterable items are
         recursively listed in detail."""


### PR DESCRIPTION
I need the name of the tag in order to access pallet properly, and parsing a wrapper just seems wrong. added a getter for the tag name.