### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ amounts of binary data with smaller amounts of additional data.
 An NBT file consists of a single GZIPped Named Tag of type TAG_Compound.
 ```
 
-Current specification is on the official [Minecraft Wiki](https://minecraft.gamepedia.com/NBT_format).
+Current specification is on the official [Minecraft Wiki](https://minecraft.wiki/w/NBT_format).
 
 This library is very suited to inspect & edit the Minecraft data files. Provided
 examples demonstrate how to:

--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@ From the initial specification by Markus Persson::
   amounts of binary data with smaller amounts of additional data.
   An NBT file consists of a single GZIPped Named Tag of type TAG_Compound.
 
-Current specification is on the official [Minecraft Wiki](https://minecraft.gamepedia.com/NBT_format).
+Current specification is on the official [Minecraft Wiki](https://minecraft.wiki/w/NBT_format).
 
 This library is very suited to inspect & edit the Minecraft data files. Provided
 examples demonstrate how to:

--- a/examples/generate_level_dat.py
+++ b/examples/generate_level_dat.py
@@ -2,7 +2,7 @@
 """
 Create a file that can be used as a basic level.dat file with all required fields
 """
-# http://www.minecraftwiki.net/wiki/Alpha_Level_Format#level.dat_Format
+# https://minecraft.wiki/w/Java_Edition_Alpha_level_format
 
 import os,sys
 import time

--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -2,7 +2,7 @@
 Handles a single chunk of data (16x16x128 blocks) from a Minecraft save.
 
 For more information about the chunck format:
-https://minecraft.gamepedia.com/Chunk_format
+https://minecraft.wiki/w/Chunk_format
 """
 
 from io import BytesIO
@@ -13,7 +13,7 @@ import array
 
 # Legacy numeric block identifiers
 # mapped to alpha identifiers in best effort
-# See https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening
+# See https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
 # TODO: move this map into a separate file
 
 block_ids = {
@@ -143,7 +143,7 @@ class AnvilSection(object):
         self.indexes = []
 
         # Is the section flattened ?
-        # See https://minecraft.gamepedia.com/1.13/Flattening
+        # See https://minecraft.wiki/w/1.13/Flattening
 
         if version == 0 or version == 1343:  # 1343 = MC 1.12.2
             self._init_array(nbt)

--- a/nbt/nbt.py
+++ b/nbt/nbt.py
@@ -2,7 +2,7 @@
 Handle the NBT (Named Binary Tag) data format
 
 For more information about the NBT format:
-https://minecraft.gamepedia.com/NBT_format
+https://minecraft.wiki/w/NBT_format
 """
 
 from struct import Struct, error as StructError

--- a/nbt/region.py
+++ b/nbt/region.py
@@ -2,7 +2,7 @@
 Handle a region file, containing 32x32 chunks.
 
 For more information about the region file format:
-https://minecraft.gamepedia.com/Region_file_format
+https://minecraft.wiki/w/Region_file_format
 """
 
 from .nbt import NBTFile, MalformedFileError

--- a/nbt/world.py
+++ b/nbt/world.py
@@ -2,7 +2,7 @@
 Handles a Minecraft world save using either the Anvil or McRegion format.
 
 For more information about the world format:
-https://minecraft.gamepedia.com/Level_format
+https://minecraft.wiki/w/Level_format
 """
 
 import os, glob, re


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.