### PR TITLE
Fix support for Minecraft version 1.12.2 (data version 1343)

### DIFF
--- a/nbt/chunk.py
+++ b/nbt/chunk.py
@@ -296,7 +296,7 @@ class AnvilChunk(Chunk):
         self.sections = {}
         if 'Sections' in self.chunk_data:
             for s in self.chunk_data['Sections']:
-                if "BlockStates" in s.keys(): # sections may only contain lighting information
+                if "BlockStates" in s.keys() or "Blocks" in s.keys(): # sections may only contain lighting information
                     self.sections[s['Y'].value] = AnvilSection(s, version)
 
 


### PR DESCRIPTION
For data version 1343, the 'Blocks' key is needed. In commit cd0133de7aa8b0023d80769e9fc6a1a78bd9fe57 the code was change to no longer create an AnvilSection if there is no 'BlockStates' key. Change this to also create an AnvilSection if there is a 'Blocks' key.

An example level with this problem can be found at <https://media.forgecdn.net/files/2629/540/Island.zip> (`get_block()` returns `None` for every block without this patch).